### PR TITLE
忽略 Nginx-Fancyindex-Theme 目录

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -128,7 +128,7 @@ odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
 cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go']
-ignore_dir = ['static', 'font', 'help']
+ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme']
 
 for mirror in mirror_list:
     if os.path.isdir(mirror):


### PR DESCRIPTION
This pull request includes a minor update to the `mirror_index.py` file. The change adds a new directory, `Nginx-Fancyindex-Theme`, to the `ignore_dir` list to ensure it is excluded from processing.