### PR TITLE
修改 Anoilis 以及 OpenEuler 需要镜像的架构

### DIFF
--- a/help_pages_template/anolis.html
+++ b/help_pages_template/anolis.html
@@ -145,7 +145,7 @@
 <div id="mirror-data">
     <h3>收录架构</h3>
     <ul>
-        <li>全部</li>
+        <li>AMD64, aarch64</li>
     </ul>
     <h3>收录版本</h3>
     <ul>

--- a/help_pages_template/openeuler.html
+++ b/help_pages_template/openeuler.html
@@ -145,7 +145,7 @@
 <div id="mirror-data">
     <h3>收录架构</h3>
     <ul>
-        <li>AMD64</li>
+        <li>AMD64, aarch64</li>
     </ul>
     <h3>收录版本</h3>
     <ul>

--- a/mirror.sh
+++ b/mirror.sh
@@ -63,7 +63,7 @@ echo "日志文件："${LOG_FILE}
 case $1 in
 anolis)
   # 上游：Anolis官方镜像
-  RSYNC_PASSWORD=Rsync@2020 rsync ${COMMON_OPTIONS} rsync_user@rsync.openanolis.cn::anolis /mnt/mirror/anolis | tee ${LOG_FILE}
+  RSYNC_PASSWORD=Rsync@2020 rsync ${COMMON_OPTIONS} --exclude='**/loongarch64' rsync_user@rsync.openanolis.cn::anolis /mnt/mirror/anolis | tee ${LOG_FILE}
   ;;
 archlinux)
   # 上游：中科大镜像
@@ -126,7 +126,7 @@ manjaro-cd)
   ;;
 openeuler)
   # 上游：OpenEuler官方
-  rsync ${COMMON_OPTIONS} --exclude='**/aarch64' --exclude='**/loongarch64' --exclude='**/ppc64le' --exclude='**/riscv64' repo.openeuler.openatom.cn::openeuler /mnt/mirror/openeuler/ | tee ${LOG_FILE}
+  rsync ${COMMON_OPTIONS} --exclude='**/loongarch64' --exclude='**/ppc64le' --exclude='**/riscv64' repo.openeuler.openatom.cn::openeuler /mnt/mirror/openeuler/ | tee ${LOG_FILE}
   ;;
 raspberrypi)
   # 上游：apt-repo.raspberrypi.org


### PR DESCRIPTION
This pull request introduces updates to the architecture support information in help pages and modifies the `mirror.sh` script to adjust synchronization rules for different distributions. Below is a summary of the most important changes:

### Updates to architecture information in help pages:

* [`help_pages_template/anolis.html`](diffhunk://#diff-9ffa0283065e5979317faaef1ed66af7f757a6fee228f9bd51540edc2e090206L148-R148): Updated the list of supported architectures from "全部" (all) to explicitly list "AMD64, aarch64".
* [`help_pages_template/openeuler.html`](diffhunk://#diff-452927d2c278c1e17b40111455ca7e8130f8f53aee98dc24a67ba578eccf0a86L148-R148): Added "aarch64" to the list of supported architectures, updating it to "AMD64, aarch64".

### Modifications to synchronization rules in `mirror.sh`:

* [`mirror.sh`](diffhunk://#diff-89b20303f14b34bbdd476ca67af9d1587e6454ccae2d4cefc8b716a8752cb92aL66-R66): Added an exclusion rule for the `loongarch64` architecture in the Anolis synchronization command.
* [`mirror.sh`](diffhunk://#diff-89b20303f14b34bbdd476ca67af9d1587e6454ccae2d4cefc8b716a8752cb92aL129-R129): Removed the exclusion rule for the `aarch64` architecture in the OpenEuler synchronization command, allowing it to be included.