### PR TITLE
修改说明文档

### DIFF
--- a/help_pages_template/anolis.html
+++ b/help_pages_template/anolis.html
@@ -141,7 +141,7 @@
         </ul>
     </div>
     <div class="col-75">
-        <h2>ubuntu镜像使用帮助</h2>
+        <h2>Anolis镜像使用帮助</h2>
 <div id="mirror-data">
     <h3>收录架构</h3>
     <ul>

--- a/help_pages_template/openeuler.html
+++ b/help_pages_template/openeuler.html
@@ -141,7 +141,7 @@
         </ul>
     </div>
     <div class="col-75">
-        <h2>ubuntu镜像使用帮助</h2>
+        <h2>OpenEuler镜像使用帮助</h2>
 <div id="mirror-data">
     <h3>收录架构</h3>
     <ul>


### PR DESCRIPTION
This pull request updates the titles of help pages for different Linux distributions to reflect their correct names. The changes ensure that the headers are accurate and contextually appropriate.

Help page title updates:

* [`help_pages_template/anolis.html`](diffhunk://#diff-9ffa0283065e5979317faaef1ed66af7f757a6fee228f9bd51540edc2e090206L144-R144): Updated the header from "ubuntu镜像使用帮助" to "Anolis镜像使用帮助" to correctly reference the Anolis distribution.
* [`help_pages_template/openeuler.html`](diffhunk://#diff-452927d2c278c1e17b40111455ca7e8130f8f53aee98dc24a67ba578eccf0a86L144-R144): Updated the header from "ubuntu镜像使用帮助" to "OpenEuler镜像使用帮助" to correctly reference the OpenEuler distribution.