### PR TITLE
新增 Homebrew 镜像源

### DIFF
--- a/help_pages_template/anaconda.html
+++ b/help_pages_template/anaconda.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/anolis.html
+++ b/help_pages_template/anolis.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/archlinux.html
+++ b/help_pages_template/archlinux.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/archlinuxcn.html
+++ b/help_pages_template/archlinuxcn.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/centos-vault.html
+++ b/help_pages_template/centos-vault.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/centos.html
+++ b/help_pages_template/centos.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/debian-cd.html
+++ b/help_pages_template/debian-cd.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/debian.html
+++ b/help_pages_template/debian.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/docker-ce.html
+++ b/help_pages_template/docker-ce.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/docker.html
+++ b/help_pages_template/docker.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/epel.html
+++ b/help_pages_template/epel.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/freebsd-pkg.html
+++ b/help_pages_template/freebsd-pkg.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/freebsd.html
+++ b/help_pages_template/freebsd.html
@@ -17,7 +17,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -75,6 +75,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/gentoo.html
+++ b/help_pages_template/gentoo.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/go.html
+++ b/help_pages_template/go.html
@@ -18,7 +18,7 @@
         <ul class="nav">
 
 
-                        <li class="nav-item">
+            <li class="nav-item">
                 <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
             </li>
 
@@ -76,6 +76,14 @@
 
             <li class="nav-item">
                 <a href="/help/go.html" class="nav-link nav-link-selected">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/homebrew-bottles.html
+++ b/help_pages_template/homebrew-bottles.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link nav-link-selected">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 
@@ -123,7 +131,7 @@
             </li>
 
             <li class="nav-item">
-                <a href="/help/ubuntu.html" class="nav-link nav-link-selected">ubuntu</a>
+                <a href="/help/ubuntu.html" class="nav-link">ubuntu</a>
             </li>
 
             <li class="nav-item">

--- a/help_pages_template/homebrew-bottles.html
+++ b/help_pages_template/homebrew-bottles.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <link rel="stylesheet" type="text/css" href="/mirror.css" media="screen" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css">
+    <title>广东工业大学开源镜像站</title>
+</head>
+
+<body class="fade-in">
+
+<header>
+    <h1><img style="vertical-align: middle;" src="/GDUT_Logo.png" width="40" height="40"/>&nbsp;广东工业大学开源镜像站</h1>
+</header>
+
+<div class="container">
+    <div class="col-25">
+        <ul class="nav">
+
+
+            <li class="nav-item">
+                <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/anolis.html" class="nav-link ">anolis</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/archlinux.html" class="nav-link ">archlinux</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/archlinuxcn.html" class="nav-link ">archlinuxcn</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/centos.html" class="nav-link ">centos</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/centos-vault.html" class="nav-link ">centos-vault</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/debian.html" class="nav-link ">debian</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/debian-cd.html" class="nav-link ">debian-cd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/docker.html" class="nav-link ">docker</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/docker-ce.html" class="nav-link ">docker-ce</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/epel.html" class="nav-link ">epel</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/freebsd.html" class="nav-link ">freebsd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/freebsd-pkg.html" class="nav-link ">freebsd-pkg</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/gentoo.html" class="nav-link ">gentoo</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kali.html" class="nav-link ">kali</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kali-images.html" class="nav-link ">kali-images</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kubernetes.html" class="nav-link ">kubernetes</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/manjaro.html" class="nav-link ">manjaro</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/manjaro-cd.html" class="nav-link ">manjaro-cd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/maven.html" class="nav-link ">maven</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/npm.html" class="nav-link ">npm</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/openeuler.html" class="nav-link ">openeuler</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/pypi.html" class="nav-link ">pypi</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/raspbian.html" class="nav-link ">raspbian</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/termux.html" class="nav-link ">termux</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu.html" class="nav-link nav-link-selected">ubuntu</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-cloud-images.html" class="nav-link ">ubuntu-cloud-images</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-ports.html" class="nav-link ">ubuntu-ports</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-releases.html" class="nav-link ">ubuntu-releases</a>
+            </li>
+
+        </ul>
+    </div>
+    <div class="col-75">
+        <h2>Homebrew Bottless镜像使用帮助</h2>
+<div id="mirror-data">
+    <h3>收录架构</h3>
+    <ul>
+        <li>全部</li>
+    </ul>
+    <h3>收录版本</h3>
+    <ul>
+        <li>全部</li>
+    </ul>
+    <h3>更新时间</h3>
+    <p>每6小时更新一次</p>
+</div>
+<div class="hr">
+    <hr/>
+</div>
+<div id="mirror-usage">
+    <h3>使用说明</h3>
+    <p><strong>注：该镜像是 Homebrew 二进制预编译包的镜像。镜像站同时提供 Homebrew 的 formula 索引的镜像（即 <code>brew update</code> 时所更新内容），请参考 <a href="/homebrew/">Homebrew 镜像使用帮助</a>。</strong></p>
+    <h3>临时替换</h3>
+    <pre><code class="bash">export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <h3>长期替换</h3>
+    <p>如果你使用 bash：</p>
+    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"' >> ~/.bash_profile
+echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"' >> ~/.bash_profile
+export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <p>如果你使用 zsh：</p>
+    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"' >> ~/.zprofile
+echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"' >> ~/.zprofile
+export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <p><strong>注：Linuxbrew 核心仓库（<code>linuxbrew-core</code>）自 2021 年 10 月 25 日（<code>brew</code> 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 <code>homebrew-core</code>。Linuxbrew 用户请依本镜像说明重新设置镜像。</strong></p>
+</div>
+    </div>
+</div>
+
+<div id="footer">
+    🏠<a target="_blank" href="http://www.gdut.edu.cn/">广东工业大学首页</a>
+    &nbsp;|&nbsp;
+    ❓<a target="_blank" href="about.html">关于我们</a>
+    &nbsp;|&nbsp;
+    📮<a href="mailto:stunic@gdut.edu.cn">联系我们</a>
+    &nbsp;|&nbsp;
+    🟢<a target="_blank" href="status.html">当前状态</a>
+</div>
+<script type="text/javascript" src="/mirror.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>

--- a/help_pages_template/homebrew-bottles.html
+++ b/help_pages_template/homebrew-bottles.html
@@ -161,19 +161,19 @@
     <h3>使用说明</h3>
     <p><strong>注：该镜像是 Homebrew 二进制预编译包的镜像。镜像站同时提供 Homebrew 的 formula 索引的镜像（即 <code>brew update</code> 时所更新内容），请参考 <a href="/homebrew/">Homebrew 镜像使用帮助</a>。</strong></p>
     <h3>临时替换</h3>
-    <pre><code class="bash">export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
-export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <pre><code class="bash">export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"</code></pre>
     <h3>长期替换</h3>
     <p>如果你使用 bash：</p>
-    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"' >> ~/.bash_profile
-echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"' >> ~/.bash_profile
-export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
-export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"' >> ~/.bash_profile
+echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"' >> ~/.bash_profile
+export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"</code></pre>
     <p>如果你使用 zsh：</p>
-    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"' >> ~/.zprofile
-echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"' >> ~/.zprofile
-export HOMEBREW_API_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles/api"
-export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.cernet.edu.cn/homebrew-bottles"</code></pre>
+    <pre><code class="bash">echo 'export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"' >> ~/.zprofile
+echo 'export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"' >> ~/.zprofile
+export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"</code></pre>
     <p><strong>注：Linuxbrew 核心仓库（<code>linuxbrew-core</code>）自 2021 年 10 月 25 日（<code>brew</code> 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 <code>homebrew-core</code>。Linuxbrew 用户请依本镜像说明重新设置镜像。</strong></p>
 </div>
     </div>

--- a/help_pages_template/homebrew.html
+++ b/help_pages_template/homebrew.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <link rel="stylesheet" type="text/css" href="/mirror.css" media="screen" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css">
+    <title>广东工业大学开源镜像站</title>
+</head>
+
+<body class="fade-in">
+
+<header>
+    <h1><img style="vertical-align: middle;" src="/GDUT_Logo.png" width="40" height="40"/>&nbsp;广东工业大学开源镜像站</h1>
+</header>
+
+<div class="container">
+    <div class="col-25">
+        <ul class="nav">
+
+
+            <li class="nav-item">
+                <a href="/help/anaconda.html" class="nav-link ">anaconda</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/anolis.html" class="nav-link ">anolis</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/archlinux.html" class="nav-link ">archlinux</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/archlinuxcn.html" class="nav-link ">archlinuxcn</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/centos.html" class="nav-link ">centos</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/centos-vault.html" class="nav-link ">centos-vault</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/debian.html" class="nav-link ">debian</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/debian-cd.html" class="nav-link ">debian-cd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/docker.html" class="nav-link ">docker</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/docker-ce.html" class="nav-link ">docker-ce</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/epel.html" class="nav-link ">epel</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/freebsd.html" class="nav-link ">freebsd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/freebsd-pkg.html" class="nav-link ">freebsd-pkg</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/gentoo.html" class="nav-link ">gentoo</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/go.html" class="nav-link ">go</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kali.html" class="nav-link ">kali</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kali-images.html" class="nav-link ">kali-images</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/kubernetes.html" class="nav-link ">kubernetes</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/manjaro.html" class="nav-link ">manjaro</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/manjaro-cd.html" class="nav-link ">manjaro-cd</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/maven.html" class="nav-link ">maven</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/npm.html" class="nav-link ">npm</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/openeuler.html" class="nav-link ">openeuler</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/pypi.html" class="nav-link ">pypi</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/raspbian.html" class="nav-link ">raspbian</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/termux.html" class="nav-link ">termux</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu.html" class="nav-link nav-link-selected">ubuntu</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-cloud-images.html" class="nav-link ">ubuntu-cloud-images</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-ports.html" class="nav-link ">ubuntu-ports</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/ubuntu-releases.html" class="nav-link ">ubuntu-releases</a>
+            </li>
+
+        </ul>
+    </div>
+    <div class="col-75">
+        <h2>Homebrew镜像使用帮助</h2>
+<div id="mirror-data">
+    <h3>收录架构</h3>
+    <ul>
+        <li>全部</li>
+    </ul>
+    <h3>收录版本</h3>
+    <ul>
+        <li>全部</li>
+    </ul>
+    <h3>更新时间</h3>
+    <p>每6小时更新一次</p>
+</div>
+<div class="hr">
+    <hr/>
+</div>
+<div id="mirror-usage">
+    <h3>使用说明</h3>
+    <p><strong>注：该镜像是 Homebrew / Linuxbrew 源程序以及 formula / cask 索引的镜像（即 <code>brew update</code> 时所更新内容）。镜像站同时提供相应的二进制预编译包的镜像，请参考 <a" href="/homebrew-bottles/">Homebrew bottles 镜像使用帮助</a></strong></p>
+    <p>镜像站提供了 <a href="https://github.com/Homebrew">https://github.com/Homebrew</a> 组织下的以下 <code >repo</code>：<code >brew</code>, <code >homebrew-core</code>, <code >homebrew-cask</code>, <code >homebrew-command-not-found</code>, <code >install</code>。</p>
+    <p><strong>注：自 brew 4.0.0 (2023 年 2 月 16 日) 起，<code >HOMEBREW_INSTALL_FROM_API</code> 会成为默认行为，无需设置。大部分用户无需再克隆 <code >homebrew-core</code> 仓库，故无需设置 <code >HOMEBREW_CORE_GIT_REMOTE</code> 环境变量；但若需要运行 <code >brew</code> 的开发命令或者 <code >brew</code> 安装在非官方支持的默认 prefix 位置，则仍需设置 <code >HOMEBREW_CORE_GIT_REMOTE</code> 环境变量。如果不想通过 API 安装，可以设置 <code >HOMEBREW_NO_INSTALL_FROM_API=1</code>。</strong></p>
+    <p><strong>注：目前，<code >homebrew-cask-{drivers,versions,fonts}</code> 已被弃用，所有 cask 合并至 <code >homebrew-cask</code> 仓库。本帮助内已移除克隆这些仓库的命令。已克隆用户（<code >brew tap</code> 查看）可使用 <code >brew untap</code> 移除废弃的仓库。</strong></p>
+    <h3>首次安装 Homebrew / Linuxbrew</h3>
+    <p>首先，需要确保系统中安装了 bash、git 和 curl，对于 macOS 用户需额外要求安装 Command Line Tools (CLT) for Xcode。</p>
+    <ul>
+        <li>对于 macOS 用户，系统自带 bash、git 和 curl，在命令行输入 <code >xcode-select --install</code> 安装 CLT for Xcode 即可。</li>
+        <li>对于 Linux 用户，系统自带 bash，仅需额外安装 git 和 curl。</li>
+    </ul>
+    <p>接着，在终端输入以下几行命令设置环境变量：</p>
+    <pre><code class="bash">export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/brew.git"
+export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"
+export HOMEBREW_INSTALL_FROM_API=1
+# export HOMEBREW_API_DOMAIN
+# export HOMEBREW_BOTTLE_DOMAIN
+# export HOMEBREW_PIP_INDEX_URL</code></pre>
+    <p>前往 <a href="/homebrew-bottles/">Homebrew bottles 镜像使用帮助</a>中「临时替换」一节设置好 <code>HOMEBREW_API_DOMAIN</code> 与 <code>HOMEBREW_BOTTLE_DOMAIN</code>。</p>
+    <p>最后，在终端运行以下命令以安装 Homebrew / Linuxbrew：</p>
+    <pre><code class="bash"># 从镜像下载安装脚本并安装 Homebrew / Linuxbrew
+git clone --depth=1 https://mirrors.gdut.edu.cn/git/homebrew/install.git brew-install
+/bin/bash brew-install/install.sh
+rm -rf brew-install
+
+# 也可从 GitHub 获取官方安装脚本安装 Homebrew / Linuxbrew
+/bin/bash -c "$(curl -fsSL https://github.com/Homebrew/install/raw/master/install.sh)"</code></pre>
+    <p>这样在首次安装的时候也可以使用镜像。更多信息请参考 <a href="https://docs.brew.sh/Installation">Homebrew 官方安装文档</a>。</p>
+    <p><strong>安装成功后需将 brew 程序的相关路径加入到环境变量中：</strong></p>
+    <ul>
+        <li>
+            <p>以下针对基于 Apple Silicon CPU 设备上的 macOS 系统（命令行运行 <code >uname -m</code> 应输出 <code >arm64</code>）上的 Homebrew：</p>
+            <pre><code class="bash">test -r ~/.bash_profile && echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bash_profile
+test -r ~/.zprofile && echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile</code></pre>
+            <p>对基于 Intel CPU 设备上的 macOS 系统（命令行运行 <code >uname -m</code> 应输出 <code >x86_64</code>）的用户可跳过本步。</p>
+        </li>
+        <li>
+            <p>以下针对 Linux 系统上的 Linuxbrew：</p>
+            <pre><code class="bash">test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"
+test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile
+test -r ~/.profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.profile
+test -r ~/.zprofile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.zprofile</code></pre>
+            <p>参考了 <a href="https://docs.brew.sh/Homebrew-on-Linux">https://docs.brew.sh/Homebrew-on-Linux</a>。</p>
+        </li>
+    </ul>
+    <h3>替换现有仓库上游</h3>
+    <p>替换 brew 程序本身的源，Homebrew / Linuxbrew 相同：</p>
+    <pre><code class="bash"># export HOMEBREW_API_DOMAIN=
+export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/brew.git"
+brew update</code></pre>
+    <p>前往 <a href="/homebrew-bottles/">Homebrew bottles 镜像使用帮助</a>中「临时替换」一节设置好 <code>HOMEBREW_API_DOMAIN</code></p>
+    <p>以下针对 macOS 系统上的 Homebrew：</p>
+    <pre><code class="bash"># 手动设置
+export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"
+
+# 注：自 brew 4.0 起，大部分 Homebrew 用户无需设置 homebrew/core 和 homebrew/cask 镜像，只需设置 HOMEBREW_API_DOMAIN 即可。
+# 如果需要使用 Homebrew 的开发命令 (如 `brew cat &lt;formula&gt;`)，则仍然需要设置 homebrew/core 和 homebrew/cask 镜像。
+# 请按需执行如下两行命令：
+brew tap --custom-remote --force-auto-update homebrew/core https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git
+brew tap --custom-remote --force-auto-update homebrew/cask https://mirrors.gdut.edu.cn/git/homebrew/homebrew-cask.git
+
+# 除 homebrew/core 和 homebrew/cask 仓库外的 tap 仓库仍然需要设置镜像
+brew tap --custom-remote --force-auto-update homebrew/command-not-found https://mirrors.gdut.edu.cn/git/homebrew/homebrew-command-not-found.git
+brew update
+
+# 或使用下面的几行命令自动设置
+export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"
+for tap in core cask command-not-found; do
+    brew tap --custom-remote --force-auto-update "homebrew/${tap}" "https://mirrors.gdut.edu.cn/git/homebrew/homebrew-${tap}.git"
+done
+brew update</code></pre>
+    <p>以下针对 Linux 系统上的 Linuxbrew：</p>
+    <pre><code class="bash">export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"
+
+# 注：自 brew 4.0 起，使用默认 prefix (即 "/home/linuxbrew/.linuxbrew") 的大部分 Homebrew 用户无需设置 homebrew/core 镜像，只需设置 HOMEBREW_API_DOMAIN 即可。
+# 如果不是默认 prefix 或者需要使用 Homebrew 的开发命令 (如 `brew cat &lt;formula&gt;`)，则仍然需要设置 homebrew/core 镜像。
+# 请按需执行如下命令：
+brew tap --custom-remote --force-auto-update homebrew/core https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git
+
+# 除 homebrew/core 仓库外的 tap 仓库仍然需要设置镜像
+brew tap --custom-remote --force-auto-update homebrew/command-not-found https://mirrors.gdut.edu.cn/git/homebrew/homebrew-command-not-found.git
+brew update</code></pre>
+    <p><strong>注：如果用户设置了环境变量 <code >HOMEBREW_BREW_GIT_REMOTE</code> 和 <code >HOMEBREW_CORE_GIT_REMOTE</code>，则每次执行 <code >brew update</code> 时，<code >brew</code> 程序本身和 Core Tap (<code >homebrew-core</code>) 的远程将被自动设置。推荐用户将这两个环境变量设置加入 shell 的 profile 设置中。</strong></p>
+    <pre><code class="bash">test -r ~/.bash_profile && echo 'export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/brew.git"' >> ~/.bash_profile  # bash
+test -r ~/.bash_profile && echo 'export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"' >> ~/.bash_profile
+test -r ~/.profile && echo 'export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/brew.git"' >> ~/.profile
+test -r ~/.profile && echo 'export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"' >> ~/.profile
+
+test -r ~/.zprofile && echo 'export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/brew.git"' >> ~/.zprofile  # zsh
+test -r ~/.zprofile && echo 'export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.gdut.edu.cn/git/homebrew/homebrew-core.git"' >> ~/.zprofile</code></pre>
+    <p>对于 <code >HOMEBREW_API_DOMAIN</code> 与其余 bottles 相关环境变量的持久化，可以参考 <a" href="/homebrew-bottles/">Homebrew Bottles 帮助</a>。</p>
+    <h3>复原仓库上游</h3>
+    <ul>
+        <li>
+            <p>以下针对 macOS 系统上的 Homebrew</p>
+            <pre><code class="bash"># brew 程序本身，Homebrew / Linuxbrew 相同
+unset HOMEBREW_API_DOMAIN
+unset HOMEBREW_BREW_GIT_REMOTE
+git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
+
+# 以下针对 macOS 系统上的 Homebrew
+unset HOMEBREW_CORE_GIT_REMOTE
+BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
+for tap in core cask command-not-found; do
+    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then  # 只复原已安装的 Tap
+        brew tap --custom-remote "homebrew/${tap}" "https://github.com/Homebrew/homebrew-${tap}"
+    fi
+done
+
+# 重新拉取远程
+brew update</code></pre>
+        </li>
+        <li>
+            <p>以下针对 Linux 系统上的 Linuxbrew</p>
+            <pre><code class="bash"># brew 程序本身，Homebrew / Linuxbrew 相同
+unset HOMEBREW_API_DOMAIN
+unset HOMEBREW_BREW_GIT_REMOTE
+git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
+
+# 以下针对 Linux 系统上的 Linuxbrew
+unset HOMEBREW_API_DOMAIN
+unset HOMEBREW_CORE_GIT_REMOTE
+brew tap --custom-remote homebrew/core https://github.com/Homebrew/homebrew-core
+brew tap --custom-remote homebrew/command-not-found https://github.com/Homebrew/homebrew-command-not-found
+
+# 重新拉取远程
+brew update</code></pre>
+        </li>
+    </ul>
+    <p><strong>注：重置回默认远程后，用户应该删除 shell 的 profile 设置中的环境变量 <code >HOMEBREW_BREW_GIT_REMOTE</code> 和 <code >HOMEBREW_CORE_GIT_REMOTE</code> 以免运行 <code >brew update</code> 时远程再次被更换。</strong></p>
+</div>
+    </div>
+</div>
+
+<div id="footer">
+    🏠<a target="_blank" href="http://www.gdut.edu.cn/">广东工业大学首页</a>
+    &nbsp;|&nbsp;
+    ❓<a target="_blank" href="about.html">关于我们</a>
+    &nbsp;|&nbsp;
+    📮<a href="mailto:stunic@gdut.edu.cn">联系我们</a>
+    &nbsp;|&nbsp;
+    🟢<a target="_blank" href="status.html">当前状态</a>
+</div>
+<script type="text/javascript" src="/mirror.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>

--- a/help_pages_template/homebrew.html
+++ b/help_pages_template/homebrew.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link nav-link-selected">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/kali-images.html
+++ b/help_pages_template/kali-images.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/kali.html
+++ b/help_pages_template/kali.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link nav-link-selected">kali</a>
             </li>
 

--- a/help_pages_template/kubernetes.html
+++ b/help_pages_template/kubernetes.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/manjaro-cd.html
+++ b/help_pages_template/manjaro-cd.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/manjaro.html
+++ b/help_pages_template/manjaro.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/maven.html
+++ b/help_pages_template/maven.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/npm.html
+++ b/help_pages_template/npm.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/openeuler.html
+++ b/help_pages_template/openeuler.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/pypi.html
+++ b/help_pages_template/pypi.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/raspbian.html
+++ b/help_pages_template/raspbian.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/termux.html
+++ b/help_pages_template/termux.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/ubuntu-ports.html
+++ b/help_pages_template/ubuntu-ports.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/ubuntu-releases.html
+++ b/help_pages_template/ubuntu-releases.html
@@ -78,6 +78,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/help_pages_template/ubuntu.html
+++ b/help_pages_template/ubuntu.html
@@ -79,6 +79,14 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew</a>
+            </li>
+
+            <li class="nav-item">
+                <a href="/help/homebrew.html" class="nav-link ">homebrew-bottles</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/kali.html" class="nav-link ">kali</a>
             </li>
 

--- a/mirror.sh
+++ b/mirror.sh
@@ -22,8 +22,8 @@ usage() {
   cat <<EOF
 Usage: $0 [mirror]
 Example: $0 debian
-Supported mirrors: anolis archlinux archlinuxcn centos debian debian-cd docker-ce
-                   elpa epel freebsd gentoo kali-images kubernetes manjaro manjaro-cd
+Supported mirrors: anolis archlinux archlinuxcn centos debian debian-cd docker-ce elpa epel
+                   freebsd gentoo homebrew-bottles kali-images kubernetes manjaro manjaro-cd
                    openeuler raspberrypi raspbian termux ubuntu ubuntu-releases
 EOF
   exit 0
@@ -107,6 +107,10 @@ gentoo)
   # 上游：masterdistfiles.gentoo.org
   # 官方文档 https://wiki.gentoo.org/wiki/Project:Infrastructure/Mirrors/Source
   rsync ${COMMON_OPTIONS} --exclude='/releases/historical' --exclude='/distfiles/**' --exclude='**/alpha' --exclude='**/bsd' --exclude='**/hppa' --exclude='**/ia64' --exclude='**/m68k' --exclude='**/mips' --exclude='**/ppc' --exclude='**/prefix' --exclude='**/s390' --exclude='**/sh' --exclude='**/sparc' masterdistfiles.gentoo.org::gentoo /mnt/mirror/gentoo | tee ${LOG_FILE}
+  ;;
+homebrew-bottles)
+  # 上游：南大镜像
+  rsync ${COMMON_OPTIONS} mirrors.nju.edu.cn::homebrew-bottles /mnt/mirror/homebrew-bottles | tee ${LOG_FILE}
   ;;
 kali-images)
   # 上游：清华镜像

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -128,7 +128,7 @@ odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
 cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go']
-ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme']
+ignore_dir = ['static', 'font', 'git', 'help', 'scripts','Nginx-Fancyindex-Theme']
 
 for mirror in mirror_list:
     if os.path.isdir(mirror):

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -338,31 +338,26 @@ server {
         proxy_cache cache_kali;
         include /home/nginx/conf/mirror/cache_2h.conf;
     }
-    # Packages、InRelease等文件 缓存2小时
-    location ~ /git/homebrew/.*/(Packages|Packages.gz|InRelease|Release|Release.gpg|Contents-.*.gz) {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_2h.conf;
-    }
 
     ##############################
     # Homebrew Bottles 缓存配置（不分片）
     ##############################
     
-    # 普通文件 缓存30天
+    # 检测到文件不存在则反代到清华
     location /homebrew-bottles/ {
+        try_files $uri $uri/ @homebrew_bottles_tuna_tsinghua;
+    }
+    location ~ /homebrew-bottles/($|.*/$) {
+        try_files $uri $uri/ @homebrew_bottles_2h_tuna_tsinghua;
+    }
+    # 普通文件 缓存30天
+    location @homebrew_bottles_tuna_tsinghua {
         include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_kali;
         include /home/nginx/conf/mirror/cache_30d.conf;
     }
     # 目录 缓存2小时
-    location ~ /homebrew-bottles/($|.*/$) {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_2h.conf;
-    }
-    # Packages、InRelease等文件 缓存2小时
-    location ~ /homebrew-bottles/.*/(Packages|Packages.gz|InRelease|Release|Release.gpg|Contents-.*.gz) {
+    location @homebrew_bottles_2h_tuna_tsinghua {
         include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_kali;
         include /home/nginx/conf/mirror/cache_2h.conf;

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -323,6 +323,52 @@ server {
     }
 
     ##############################
+    # Homebrew 缓存配置（不分片）
+    ##############################
+
+    # 普通文件 缓存30天
+    location /git/homebrew/ {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 目录 缓存2小时
+    location ~ /git/homebrew/($|.*/$) {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+    # Packages、InRelease等文件 缓存2小时
+    location ~ /git/homebrew/.*/(Packages|Packages.gz|InRelease|Release|Release.gpg|Contents-.*.gz) {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
+    # Homebrew Bottles 缓存配置（不分片）
+    ##############################
+    
+    # 普通文件 缓存30天
+    location /homebrew-bottles/ {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 目录 缓存2小时
+    location ~ /homebrew-bottles/($|.*/$) {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+    # Packages、InRelease等文件 缓存2小时
+    location ~ /homebrew-bottles/.*/(Packages|Packages.gz|InRelease|Release|Release.gpg|Contents-.*.gz) {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_kali;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
     # nexus 反代
     ##############################
 


### PR DESCRIPTION
This pull request adds navigation links for "homebrew" and "homebrew-bottles" across multiple help pages and introduces a new help page specifically for "homebrew-bottles." These changes enhance the navigation and provide detailed usage instructions for the "homebrew-bottles" mirror.

### Navigation Updates:
* Added "homebrew" and "homebrew-bottles" links to the navigation menus in the following help pages: `anaconda.html`, `anolis.html`, `archlinux.html`, `archlinuxcn.html`, `centos.html`, `centos-vault.html`, `debian.html`, `debian-cd.html`, `docker.html`, `docker-ce.html`, `epel.html`, `freebsd.html`, `freebsd-pkg.html`, `gentoo.html`, and `go.html`. [[1]](diffhunk://#diff-10649faabc9b5961d84cbdef1deefa83ec0163a7245d5c728db2cc890e5675ddR81-R88) [[2]](diffhunk://#diff-9ffa0283065e5979317faaef1ed66af7f757a6fee228f9bd51540edc2e090206R81-R88) [[3]](diffhunk://#diff-622a0bb7347a0d551ccc9ba71f50da1fc578f96fed21f3474e4f0e5052a33c8dR81-R88) [[4]](diffhunk://#diff-2d899db72d6eb345cc5e7c5d3cf5d3f8f3e578e9c04664c236d34728d72d134bR80-R87) [[5]](diffhunk://#diff-7409f7fa06e1b3086b20e8578aad89958dc56fb1a13085aff3eb0fc7f5ccbc43R81-R88) [[6]](diffhunk://#diff-7ad9ae9b224b1b3f0ef5e841ff03a6f9bf263df3a54a11c1746c99e41d072276R81-R88) [[7]](diffhunk://#diff-421eb36b2f4345e135dc8251e6323d151f3698156523c40e0daa59e6492ed0fdR80-R87) [[8]](diffhunk://#diff-ae002fed7d910a4260229aa3f094fdda0be87e7c2c3e0f1969c1fbed43bae72dR81-R88) [[9]](diffhunk://#diff-b3ed98ffccaa94f5469077c3e6bb32fda00b565e6c2317d685a3293bb3662368R81-R88) [[10]](diffhunk://#diff-33ee3822a66432bb96e33b00016b13efad1383c59c854b809447e14812339570R81-R88) [[11]](diffhunk://#diff-3569eb78afe3e1f97c2fab268024138f77a8c3f18d3455259241200a1bcc3dd6R81-R88) [[12]](diffhunk://#diff-83d7c99222ba5b20a128119ecac14dfb67f4bbe8d818df1545c36cd6f8da91c4R81-R88) [[13]](diffhunk://#diff-103a472807df020b52e29552358cfd3191032b0f4fbb1ac97def9c87dcacb48cR80-R87) [[14]](diffhunk://#diff-b59b02520c58b76353115f1568498eb9c01803dbf8ed6fb18f8eb4504cb547a0R81-R88) [[15]](diffhunk://#diff-84003493a0ad501825242ffe84dfc5a799906d775d05cabd591b06a2684b4393R81-R88)

### New Help Page:
* Added a new file, `homebrew-bottles.html`, which provides detailed usage instructions for the "homebrew-bottles" mirror, including temporary and long-term configuration steps for bash and zsh users. The page also includes information about supported architectures, versions, and update frequency.