### PR TITLE
修复页面链接问题

### DIFF
--- a/help_pages_template/homebrew-bottles.html
+++ b/help_pages_template/homebrew-bottles.html
@@ -167,7 +167,7 @@
 </div>
 <div id="mirror-usage">
     <h3>使用说明</h3>
-    <p><strong>注：该镜像是 Homebrew 二进制预编译包的镜像。镜像站同时提供 Homebrew 的 formula 索引的镜像（即 <code>brew update</code> 时所更新内容），请参考 <a href="/homebrew/">Homebrew 镜像使用帮助</a>。</strong></p>
+    <p><strong>注：该镜像是 Homebrew 二进制预编译包的镜像。镜像站同时提供 Homebrew 的 formula 索引的镜像（即 <code>brew update</code> 时所更新内容），请参考 <a href="/help/homebrew.html">Homebrew 镜像使用帮助</a>。</strong></p>
     <h3>临时替换</h3>
     <pre><code class="bash">export HOMEBREW_API_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles/api"
 export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.gdut.edu.cn/homebrew-bottles"</code></pre>


### PR DESCRIPTION
This pull request includes a minor update to the `help_pages_template/homebrew-bottles.html` file. The change updates a hyperlink reference to point to a new URL for the Homebrew mirror usage help page.

* Updated the hyperlink in the `<p>` tag under the "使用说明" section to reference `/help/homebrew.html` instead of `/homebrew/`.