### PR TITLE
配置缓存加速策略

### DIFF
--- a/help_pages_template/anolis.html
+++ b/help_pages_template/anolis.html
@@ -150,7 +150,7 @@
     </div>
     <div class="col-75">
         <h2>Anolis镜像使用帮助</h2>
-<div id="mirror-data">
+<!-- <div id="mirror-data">
     <h3>收录架构</h3>
     <ul>
         <li>AMD64, aarch64</li>
@@ -164,11 +164,12 @@
 </div>
 <div class="hr">
     <hr/>
-</div>
+</div> -->
 <div id="mirror-usage">
     <h3>介绍</h3>
     <p>Anolis OS 8是OpenAnolis社区推出的完全开源、中立、开放的发行版，它支持多计算架构，也面向云端场景优化，100%兼容CentOS 8软件生态。Anolis OS 8旨在为广大开发者和运维人员提供稳定、高性能、安全、可靠、开源的操作系统服务。</p>
     <h3>使用说明</h3>
+    <p>由于Anolis镜像高达40TB+，故我们不进行全量镜像，而是进行缓存。回源站点为阿里云镜像站。所有数据被请求过一次后即会缓存到服务器硬盘，缓存30天（对于会变动的文件，缓存时间为2小时）。</p>
     <p>首先备份 <code>/etc/yum.repos.d/openEuler.repo</code></p>
     <pre><code class="bash">mv /etc/yum.repos.d/openEuler.repo /etc/yum.repos.d/openEuler.repo.backup</code></pre>
     <p>根据对应的OpenEuler版本，编辑/etc/yum.repos.d/openEuler.repo文件, 修改为对应内容。（详见后面配置参考）</p>

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -1,6 +1,8 @@
 # 缓存目录所在磁盘大小为148G，下面所有配置加起来不能超过这个数（建议再小一点，留些空间，所以这里定最大可用空间之和为120G）
 # anaconda 缓存【自动预热】
 proxy_cache_path /home/mirror/nginx_cache/anaconda levels=2:2 keys_zone=cache_anaconda:2m max_size=40G inactive=30d use_temp_path=off;
+# anolis 缓存
+proxy_cache_path /home/mirror/nginx_cache/anlolis levels=2:2 keys_zone=cache_anolis:1m max_size=5G inactive=30d use_temp_path=off;
 # centos （非x86_64）缓存
 proxy_cache_path /home/mirror/nginx_cache/centos levels=2:2 keys_zone=cache_centos:1m max_size=5G inactive=30d use_temp_path=off;
 # centos-vault 缓存
@@ -13,8 +15,14 @@ proxy_cache_path /home/mirror/nginx_cache/epel levels=2:2 keys_zone=cache_epel:1
 proxy_cache_path /home/mirror/nginx_cache/freebsd-pkg levels=2:2 keys_zone=cache_freebsd_pkg:2m max_size=10G inactive=2h use_temp_path=off;
 # gentoo （distfiles）缓存【自动预热】
 proxy_cache_path /home/mirror/nginx_cache/gentoo levels=2:2 keys_zone=cache_gentoo:4m max_size=20G inactive=30d use_temp_path=off;
+# homebrew 缓存
+proxy_cache_path /home/mirror/nginx_cache/homebrew levels=2:2 keys_zone=cache_homebrew:2m max_size=10G inactive=2h use_temp_path=off;
+# homebrew-bottles 缓存
+proxy_cache_path /home/mirror/nginx_cache/homebrew_bottles levels=2:2 keys_zone=cache_homebrew_bottles:2m max_size=10G inactive=2h use_temp_path=off;
 # kali 缓存【自动预热】
 proxy_cache_path /home/mirror/nginx_cache/kali levels=2:2 keys_zone=cache_kali:2m max_size=10G inactive=30d use_temp_path=off;
+# openeuler （非AMD64, arm64）缓存
+proxy_cache_path /home/mirror/nginx_cache/openeuler levels=2:2 keys_zone=cache_openeuler:1m max_size=5G inactive=30d use_temp_path=off;
 # pypi 缓存【自动预热】
 proxy_cache_path /home/mirror/nginx_cache/pypi levels=2:2 keys_zone=cache_pypi:2m max_size=40G inactive=30d use_temp_path=off;
 # ubuntu （i386）缓存
@@ -25,7 +33,7 @@ proxy_cache_path /home/mirror/nginx_cache/ubuntu-ports levels=2:2 keys_zone=cach
 # upstream 上游服务器（回源服务器/源站）
 # 清华
 upstream tuna_tsinghua {
-    server mirrors4.tuna.tsinghua.edu.cn:443;
+    server mirrors6.tuna.tsinghua.edu.cn:443;
 }
 # 清华ipv6（速度比ipv4快）
 #upstream tuna_tsinghua_ipv6 {
@@ -39,9 +47,12 @@ upstream ustc {
 upstream aliyun {
     server mirrors.aliyun.com:443;
 }
+upstream openeuler {
+    server repo.openeuler.openatom.cn:443;
+}
 # Nexus（自己搭的）
 upstream nexus {
-    server 10.233.35.123:8081;
+    server 10.107.113.89:8081;
 }
 
 # Harbor（自己搭的）
@@ -69,9 +80,17 @@ server {
     ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
 
     # 允许列目录
-    autoindex on;
-    autoindex_localtime on;
-    autoindex_exact_size on;
+    #autoindex on;
+    #autoindex_localtime on;
+    #autoindex_exact_size on;
+    fancyindex on; # 使用fancyindex
+    fancyindex_exact_size off; # 不显示精确大小
+    fancyindex_time_format "%Y-%m-%d %H:%M";# 文件日期
+    fancyindex_localtime on;# 使用用户本地时间
+    # 页面头
+    fancyindex_header /Nginx-Fancyindex-Theme/gdut-mirrors/header.html;
+    # 页尾
+    fancyindex_footer /Nginx-Fancyindex-Theme/gdut-mirrors/footer.html;
     charset utf-8;
 
     # location 匹配顺序： 精确匹配（=） > 普通匹配（非/结尾的完整路径） > 常规字符串开头（^~） > 正则（~区分大小写 ~*不区分大小写 匹配成功就停止匹配） > 最长字符串（会遍历location再进行判断）
@@ -94,12 +113,28 @@ server {
     }
 
     ##############################
+    # anolis 配置
+    ##############################
+
+    # 检测到文件不存在则反代到阿里云
+    location /anolis/ {
+         try_files $uri $uri/ @anolis_aliyun;
+    }
+
+    # 阿里云的所有文件缓存30天
+    location @anolis_aliyun {
+        include /home/nginx/conf/mirror/proxy_pass_aliyun.conf;
+        proxy_cache cache_anolis;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+
+    ##############################
     # centos 配置（非x86_64没有同步）
     ##############################
 
     # 检测到文件不存在则反代到清华
     location /centos/ {
-        try_files $uri $uri/ @centos_tuna_tsinghua;
+         try_files $uri $uri/ @centos_tuna_tsinghua;
     }
 
     # 清华的所有文件缓存30天
@@ -197,6 +232,47 @@ server {
     }
 
     ##############################
+    # Homebrew 缓存配置（不分片）
+    ##############################
+
+    # 普通文件 缓存30天
+    location /git/homebrew/ {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_homebrew;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 目录 缓存2小时
+    location ~ /git/homebrew/($|.*/$) {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_homebrew;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
+    # Homebrew Bottles 缓存配置（不分片）
+    ##############################
+
+    # 检测到文件不存在则反代到清华
+    location /homebrew-bottles/ {
+        try_files $uri $uri/ @homebrew_bottles_tuna_tsinghua;
+    }
+    location ~ /homebrew-bottles/($|.*/$) {
+        try_files $uri $uri/ @homebrew_bottles_2h_tuna_tsinghua;
+    }
+    # 普通文件 缓存30天
+    location @homebrew_bottles_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_homebrew_bottles;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 目录 缓存2小时
+    location @homebrew_bottles_2h_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_homebrew_bottles;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
     # ubuntu 配置（i386没有同步）
     ##############################
 
@@ -216,6 +292,22 @@ server {
         include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_ubuntu;
         include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
+    # openeuler 配置（非AMD64, arm64）
+    ##############################
+
+    # 检测到文件不存在则反代到阿里云
+    location /openeuler/ {
+         try_files $uri $uri/ @openeuler_aliyun;
+    }
+
+    # 阿里云的所有文件缓存30天
+    location @openeuler_aliyun {
+        include /home/nginx/conf/mirror/proxy_pass_aliyun.conf;
+        proxy_cache cache_openeuler;
+        include /home/nginx/conf/mirror/cache_30d.conf;
     }
 
     ##############################
@@ -323,47 +415,6 @@ server {
     }
 
     ##############################
-    # Homebrew 缓存配置（不分片）
-    ##############################
-
-    # 普通文件 缓存30天
-    location /git/homebrew/ {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_30d.conf;
-    }
-    # 目录 缓存2小时
-    location ~ /git/homebrew/($|.*/$) {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_2h.conf;
-    }
-
-    ##############################
-    # Homebrew Bottles 缓存配置（不分片）
-    ##############################
-    
-    # 检测到文件不存在则反代到清华
-    location /homebrew-bottles/ {
-        try_files $uri $uri/ @homebrew_bottles_tuna_tsinghua;
-    }
-    location ~ /homebrew-bottles/($|.*/$) {
-        try_files $uri $uri/ @homebrew_bottles_2h_tuna_tsinghua;
-    }
-    # 普通文件 缓存30天
-    location @homebrew_bottles_tuna_tsinghua {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_30d.conf;
-    }
-    # 目录 缓存2小时
-    location @homebrew_bottles_2h_tuna_tsinghua {
-        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
-        proxy_cache cache_kali;
-        include /home/nginx/conf/mirror/cache_2h.conf;
-    }
-
-    ##############################
     # nexus 反代
     ##############################
 
@@ -415,7 +466,14 @@ server {
 
     # harbor
     location /docker/ {
-        rewrite ^/(.*) https://harbor permanent;
+        #rewrite ^/(.*) https://registry.gdut.edu.cn permanent;
+        proxy_set_header Authorization     "Basic cm9ib3Qkdmlldy1yZWdpc3RyeTphZTd6ZmxkRFVjNFdBRkdLMGR2WDMySm5lSE9RSDFwZg==";
+        #proxy_pass http://127.0.0.1:8008/;
+        proxy_pass http://10.104.87.151/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        #proxy_set_header X-Forwarded-Proto $scheme;
     }
 
 


### PR DESCRIPTION
This pull request makes several updates to the `nginx_conf/conf/mirror/mirror.conf` file to enhance caching and proxy configurations for various repositories and introduces changes to the `help_pages_template/anolis.html` file to update content and improve usability. The most notable changes include adding new caching configurations for `anolis`, `homebrew`, and `openeuler`, switching upstream servers, and updating the directory indexing settings.

### Nginx Configuration Updates:

* **New Cache Configurations:**
  - Added caching for `anolis`, `homebrew`, `homebrew-bottles`, and `openeuler` repositories with specific cache paths, sizes, and inactive durations. [[1]](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656R4-R5) [[2]](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656R18-R25) [[3]](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656R115-R130) [[4]](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656R234-R274) [[5]](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656R297-R312)

* **Upstream Server Changes:**
  - Updated upstream server for Tsinghua mirrors to use an IPv6 address for improved performance.
  - Added a new upstream server for `openeuler`.
  - Updated the Nexus upstream server address.

* **Directory Indexing Changes:**
  - Replaced default autoindex settings with `fancyindex` for enhanced directory listing, including custom headers, footers, and formatting options.

* **Other Proxy Updates:**
  - Modified the `docker` location block to include new proxy headers and updated the proxy pass URL.

### Help Page Updates:

* **Content Updates:**
  - Added a description of the caching mechanism for `anolis` mirrors, explaining the use of a 40TB+ cache with specific retention policies.
  - Commented out unused sections related to mirror data for better clarity.