### PR TITLE
设置 Anolis 为缓存加速

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -127,7 +127,7 @@ html = HEADER
 odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
-cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go']
+cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'anolis']
 ignore_dir = ['static', 'font', 'git', 'help', 'scripts','Nginx-Fancyindex-Theme']
 
 for mirror in mirror_list:


### PR DESCRIPTION
This pull request includes a minor update to the `mirror_index.py` file, adding support for an additional mirror type.

* [`mirror_index.py`](diffhunk://#diff-8ee58f476a535222ee23f16649b4d58b4bb6a2530d05d04fc343778951d689d3L130-R130): Added `'anolis'` to the `cdn_mirror_list` to include it as a supported CDN mirror.