### PR TITLE
修改代理加速配置

### DIFF
--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -2,7 +2,7 @@
 # anaconda 缓存【自动预热】
 proxy_cache_path /home/mirror/nginx_cache/anaconda levels=2:2 keys_zone=cache_anaconda:2m max_size=40G inactive=30d use_temp_path=off;
 # anolis 缓存
-proxy_cache_path /home/mirror/nginx_cache/anlolis levels=2:2 keys_zone=cache_anolis:1m max_size=5G inactive=30d use_temp_path=off;
+proxy_cache_path /home/mirror/nginx_cache/anolis levels=2:2 keys_zone=cache_anolis:1m max_size=5G inactive=30d use_temp_path=off;
 # centos （非x86_64）缓存
 proxy_cache_path /home/mirror/nginx_cache/centos levels=2:2 keys_zone=cache_centos:1m max_size=5G inactive=30d use_temp_path=off;
 # centos-vault 缓存
@@ -43,10 +43,15 @@ upstream tuna_tsinghua {
 upstream ustc {
     server cernet.mirrors.ustc.edu.cn:443;
 }
+# 南大
+upstream nju {
+    server mirror.nju.edu.cn:443;
+}
 # 阿里云
 upstream aliyun {
     server mirrors.aliyun.com:443;
 }
+# OpenEuler
 upstream openeuler {
     server repo.openeuler.openatom.cn:443;
 }
@@ -116,14 +121,9 @@ server {
     # anolis 配置
     ##############################
 
-    # 检测到文件不存在则反代到阿里云
+    # 普通文件 缓存30天
     location /anolis/ {
-         try_files $uri $uri/ @anolis_aliyun;
-    }
-
-    # 阿里云的所有文件缓存30天
-    location @anolis_aliyun {
-        include /home/nginx/conf/mirror/proxy_pass_aliyun.conf;
+        include /home/nginx/conf/mirror/proxy_pass_nju.conf;
         proxy_cache cache_anolis;
         include /home/nginx/conf/mirror/cache_30d.conf;
     }
@@ -300,12 +300,12 @@ server {
 
     # 检测到文件不存在则反代到阿里云
     location /openeuler/ {
-         try_files $uri $uri/ @openeuler_aliyun;
+         try_files $uri $uri/ @openeuler_tuna_tsinghua;
     }
 
     # 阿里云的所有文件缓存30天
-    location @openeuler_aliyun {
-        include /home/nginx/conf/mirror/proxy_pass_aliyun.conf;
+    location @openeuler_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_openeuler;
         include /home/nginx/conf/mirror/cache_30d.conf;
     }
@@ -497,4 +497,4 @@ server {
     #    access_log off;
     #}
 
-    }
+}

--- a/nginx_conf/conf/mirror/proxy_pass_nju.conf
+++ b/nginx_conf/conf/mirror/proxy_pass_nju.conf
@@ -1,0 +1,3 @@
+proxy_pass  https://nju; # 回源南大ipv4
+proxy_set_header Host "mirror.nju.edu.cn";
+proxy_set_header User-Agent "Nginx Proxy";


### PR DESCRIPTION
This pull request makes several updates to the Nginx configuration for the mirror service, including fixing a typo, adding a new upstream server, and modifying proxy configurations for specific repositories. These changes aim to improve the accuracy and functionality of the mirror setup.

### Fixes and corrections:
* Fixed a typo in the `proxy_cache_path` directive for the Anolis repository by correcting `anlolis` to `anolis`.

### New upstream server:
* Added a new upstream server for Nanjing University (`nju`) to the configuration.

### Proxy configuration updates:
* Updated the Anolis repository configuration to use the Nanjing University upstream server (`proxy_pass_nju.conf`) instead of Aliyun.
* Updated the OpenEuler repository configuration to use the TUNA Tsinghua upstream server (`proxy_pass_tsinghua.conf`) instead of Aliyun.

### New proxy configuration file:
* Created a new proxy configuration file, `proxy_pass_nju.conf`, for the Nanjing University upstream server, including `proxy_pass`, `proxy_set_header Host`, and `proxy_set_header User-Agent` directives.