### PR TITLE
OpenEuler 只全量同步 AMD64

### DIFF
--- a/mirror.sh
+++ b/mirror.sh
@@ -130,7 +130,7 @@ manjaro-cd)
   ;;
 openeuler)
   # 上游：OpenEuler官方
-  rsync ${COMMON_OPTIONS} --exclude='**/loongarch64' --exclude='**/ppc64le' --exclude='**/riscv64' repo.openeuler.openatom.cn::openeuler /mnt/mirror/openeuler/ | tee ${LOG_FILE}
+  rsync ${COMMON_OPTIONS} --exclude='**/aarch64' --exclude='**/loongarch64' --exclude='**/ppc64le' --exclude='**/riscv64' repo.openeuler.openatom.cn::openeuler /mnt/mirror/openeuler/ | tee ${LOG_FILE}
   ;;
 raspberrypi)
   # 上游：apt-repo.raspberrypi.org


### PR DESCRIPTION
This pull request includes a small adjustment to the `mirror.sh` script for the `openeuler` case. The change updates the `rsync` command to exclude the `aarch64` architecture in addition to the previously excluded architectures.

* [`mirror.sh`](diffhunk://#diff-89b20303f14b34bbdd476ca67af9d1587e6454ccae2d4cefc8b716a8752cb92aL133-R133): Modified the `rsync` command in the `openeuler` case to add `--exclude='**/aarch64'` to the list of excluded architectures.