### PR TITLE
忽略 `certs` 目录

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -128,7 +128,7 @@ odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
 cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'anolis']
-ignore_dir = ['static', 'font', 'git', 'help', 'scripts','Nginx-Fancyindex-Theme']
+ignore_dir = ['static', 'font', 'git', 'help', 'certs', 'scripts','Nginx-Fancyindex-Theme']
 
 for mirror in mirror_list:
     if os.path.isdir(mirror):


### PR DESCRIPTION
This pull request makes a small update to the `mirror_index.py` file by adding `certs` to the `ignore_dir` list. This ensures that directories containing certificates are excluded during processing.