### PR TITLE
修改 Anolis 镜像的回源站点为阿里云镜像站

### DIFF
--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -123,7 +123,7 @@ server {
 
     # 普通文件 缓存30天
     location /anolis/ {
-        include /home/nginx/conf/mirror/proxy_pass_nju.conf;
+        include /home/nginx/conf/mirror/proxy_pass_aliyun.conf;
         proxy_cache cache_anolis;
         include /home/nginx/conf/mirror/cache_30d.conf;
     }


### PR DESCRIPTION
This pull request updates the `nginx_conf/conf/mirror/mirror.conf` file to change the proxy configuration for the `/anolis/` location. The key change is switching the included proxy configuration file from `proxy_pass_nju.conf` to `proxy_pass_aliyun.conf`.

* Updated proxy configuration:
  * Changed the included file for the `/anolis/` location from `proxy_pass_nju.conf` to `proxy_pass_aliyun.conf` to alter the proxy behavior. (`[nginx_conf/conf/mirror/mirror.confL126-R126](diffhunk://#diff-6c501c4d52be346a48091ffe852ab44b3a6fc9f6c7c24caf6e465b2e9db7f656L126-R126)`)