### PR TITLE
添加镜像站文档中心链接

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -108,6 +108,7 @@ FOOTER = """
         <ul>
             <li><a target="_blank" href="http://www.gdut.edu.cn/">🏠 广东工业大学首页</a></li>
             <li><a target="_blank" href="about.html">❓ 关于我们</a></li>
+            <li><a target="_blank" href="https://docs.stunic.gdut.edu.cn/s/d6a3f671-45f2-4c51-9a51-c651f3a7d6ac/doc/5bm5bel6zwc5yop56uz5l255so5pah5qgj-XtDBSIgjtB">📖 文档中心</a></li>
             <li><a target="_blank" href="status.html">🟢 当前状态</a></li>
         </ul>
     </div>
@@ -119,6 +120,8 @@ FOOTER = """
     ❓<a target="_blank" href="about.html">关于我们</a>
     &nbsp;|&nbsp;
     📮<a href="mailto:stunic@gdut.edu.cn">联系我们</a>
+    &nbsp;|&nbsp;
+    📖<a target="_blank" href="https://docs.stunic.gdut.edu.cn/s/d6a3f671-45f2-4c51-9a51-c651f3a7d6ac/doc/5bm5bel6zwc5yop56uz5l255so5pah5qgj-XtDBSIgjtB">文档中心</a>
     &nbsp;|&nbsp;
     🟢<a target="_blank" href="status.html">当前状态</a>
 </div>


### PR DESCRIPTION
This pull request updates the `mirror_index.py` file to include links to a new documentation center in both the navigation menu and the footer.

### Additions to navigation and footer:

* Added a "📖 文档中心" link to the navigation menu, pointing to the documentation center URL.
* Added a "📖 文档中心" link to the footer, also pointing to the documentation center URL.