### PR TITLE
添加 Rust Cargo 镜像代理

### DIFF
--- a/help_pages_template/anaconda.html
+++ b/help_pages_template/anaconda.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/anolis.html
+++ b/help_pages_template/anolis.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/archlinux.html
+++ b/help_pages_template/archlinux.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/archlinuxcn.html
+++ b/help_pages_template/archlinuxcn.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/centos-vault.html
+++ b/help_pages_template/centos-vault.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/centos.html
+++ b/help_pages_template/centos.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/crates.io-index.html
+++ b/help_pages_template/crates.io-index.html
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <link rel="stylesheet" type="text/css" href="/mirror.css" media="screen" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-dark.min.css">
     <title>广东工业大学开源镜像站</title>
 </head>
 
@@ -42,7 +43,7 @@
             </li>
 
             <li class="nav-item">
-                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+                <a href="/help/crates.io-index.html" class="nav-link nav-link-selected">crates.io-index</a>
             </li>
 
             <li class="nav-item">
@@ -94,7 +95,7 @@
             </li>
 
             <li class="nav-item">
-                <a href="/help/kali-images.html" class="nav-link nav-link-selected">kali-images</a>
+                <a href="/help/kali-images.html" class="nav-link ">kali-images</a>
             </li>
 
             <li class="nav-item">
@@ -152,24 +153,27 @@
         </ul>
     </div>
     <div class="col-75">
-        <h2>kali-images镜像使用帮助</h2>
-<div id="mirror-data">
-    <h3>收录架构</h3>
-     <ul>
-        <li>amd64</li>
-     </ul>
-    <h3>收录版本</h3>
-     <ul>
-        <li>最新版、weekly</li>
-     </ul>
-    <h3>更新时间</h3>
-    <p>每6小时更新一次</p>
-</div>
-<div class="hr"><hr /></div>
+        <h2>Rust crates.io 稀疏索引镜像使用帮助</h2>
 <div id="mirror-usage">
     <h3>使用说明</h3>
-    <p>Kali Linux 安装光盘。请自行浏览目录挑选下载。</p>
+    <p>proxy代理仓库。本站也支持https。</p>
+    <p>编辑 <code>$CARGO_HOME/config.toml</code> 文件，添加以下内容：</p>
+    <pre><code class="bash">[registries]
+cargo-gdut = { index = "sparse+http://mirrors.gdut.edu.cn/repository/crates.io-index/" }
+
+[registries.cargo-hosted]
+index = "sparse+http://mirrors.gdut.edu.cn/repository/crates.io-index/"
+
+[source.crates-io]
+replace-with = "cargo-gdut"</code></pre>
+    <p>注：<code>sparse+</code> 表示在使用稀疏索引，链接末尾的 <code>/</code> 不能缺少。</p>
+    <p>注：<code>$CARGO_HOME</code>：在 Windows 系统默认为：<code>%USERPROFILE%\.cargo</code>，在类 Unix 系统默认为：<code>$HOME/.cargo</code>。</p>
+    <p>注：cargo 仍会尝试读取不带 <code>.toml</code> 扩展名的配置文件（即 <code>$CARGO_HOME/config</code>），但从 1.39 版本起，cargo 引入了对 <code>.toml</code> 扩展名的支持，并将其设为首选格式。请根据使用的 cargo 版本选择适当的配置文件名。</p>
+    <p>注：使用 <code>cargo search</code>、<code>cargo info</code> 等命令时需要添加 <code>--registry mirror</code>，例如 <code>cargo search --registry cargo-gdut reqwest</code>。</p>
+    <p>截至目前，可以通过 <code>cargo +nightly -Z sparse-registry update</code> 使用稀疏索引。</p>
+    <p>cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以直接使用而不需要开启 nightly。</p>
 </div>
+
     </div>
 </div>
 
@@ -183,5 +187,7 @@
     🟢<a target="_blank" href="status.html">当前状态</a>
 </div>
 <script type="text/javascript" src="/mirror.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
 </body>
 </html>

--- a/help_pages_template/debian-cd.html
+++ b/help_pages_template/debian-cd.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/debian.html
+++ b/help_pages_template/debian.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link nav-link-selected">debian</a>
             </li>
 

--- a/help_pages_template/docker-ce.html
+++ b/help_pages_template/docker-ce.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/docker.html
+++ b/help_pages_template/docker.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/epel.html
+++ b/help_pages_template/epel.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/freebsd-pkg.html
+++ b/help_pages_template/freebsd-pkg.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/freebsd.html
+++ b/help_pages_template/freebsd.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/gentoo.html
+++ b/help_pages_template/gentoo.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/go.html
+++ b/help_pages_template/go.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/homebrew-bottles.html
+++ b/help_pages_template/homebrew-bottles.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/homebrew.html
+++ b/help_pages_template/homebrew.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/kali.html
+++ b/help_pages_template/kali.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/kubernetes.html
+++ b/help_pages_template/kubernetes.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/manjaro-cd.html
+++ b/help_pages_template/manjaro-cd.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/manjaro.html
+++ b/help_pages_template/manjaro.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/maven.html
+++ b/help_pages_template/maven.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/npm.html
+++ b/help_pages_template/npm.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/openeuler.html
+++ b/help_pages_template/openeuler.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/pypi.html
+++ b/help_pages_template/pypi.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/raspbian.html
+++ b/help_pages_template/raspbian.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/termux.html
+++ b/help_pages_template/termux.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/ubuntu-ports.html
+++ b/help_pages_template/ubuntu-ports.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/ubuntu-releases.html
+++ b/help_pages_template/ubuntu-releases.html
@@ -42,6 +42,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/help_pages_template/ubuntu.html
+++ b/help_pages_template/ubuntu.html
@@ -43,6 +43,10 @@
             </li>
 
             <li class="nav-item">
+                <a href="/help/crates.io-index.html" class="nav-link ">crates.io-index</a>
+            </li>
+
+            <li class="nav-item">
                 <a href="/help/debian.html" class="nav-link ">debian</a>
             </li>
 

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -451,6 +451,11 @@ server {
         #rewrite ^/(.*) /nexus/#browse/browse:go permanent;
         rewrite ^/(.*) /service/rest/repository/browse/go/ permanent;
     }
+    # rust
+    location /crates.io-index/ {
+        #rewrite ^/(.*) /nexus/#browse/browse:rust permanent;
+        rewrite ^/(.*) /service/rest/repository/browse/crates.io-index/ permanent;
+    }
     # HTML View
     location /service/ {
         # proxy_redirect off;


### PR DESCRIPTION
This pull request introduces a new help page for the `crates.io-index` repository and updates navigation menus across multiple existing help pages to include links to this new page. These changes enhance the discoverability of the `crates.io-index` help page and provide detailed usage instructions for Rust's sparse index feature.

### Addition of `crates.io-index` help page:

* [`help_pages_template/crates.io-index.html`](diffhunk://#diff-9ac719c25f1023f5c25888a0567b61cf1cb49e84346a7f76734e45b7fd96e439R1-R193): Created a new help page with detailed instructions for configuring Rust's `cargo` to use the sparse index mirror hosted by GDUT. Includes information on setup, compatibility, and usage examples.

### Updates to navigation menus:

* Added a link to the new `crates.io-index` help page in the navigation menus of the following files:
  - `help_pages_template/anaconda.html`
  - `help_pages_template/anolis.html`
  - `help_pages_template/archlinux.html`
  - `help_pages_template/archlinuxcn.html`
  - `help_pages_template/centos-vault.html`
  - `help_pages_template/centos.html`
  - `help_pages_template/debian-cd.html`
  - `help_pages_template/debian.html`
  - `help_pages_template/docker-ce.html`
  - `help_pages_template/docker.html`
  - `help_pages_template/epel.html`
  - `help_pages_template/freebsd-pkg.html`
  - `help_pages_template/freebsd.html`
  - `help_pages_template/gentoo.html`
  - `help_pages_template/go.html`
  - `help_pages_template/homebrew-bottles.html`
  - `help_pages_template/homebrew.html`
  - `help_pages_template/kali-images.html`
  - `help_pages_template/kali.html`

These changes ensure consistent navigation across the help pages and make the `crates.io-index` documentation easily accessible.