### PR TITLE
修改脚本，添加 Rust 代理

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -147,7 +147,7 @@ html = HEADER
 odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
-cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go']
+cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go']
 ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme', 'certs', 'git', 'scripts', 'ubuntu-cloud-images']
 
 for mirror in mirror_list:


### PR DESCRIPTION
This pull request updates the `mirror_index.py` file to include an additional mirror source in the `cdn_mirror_list`.

* [`mirror_index.py`](diffhunk://#diff-8ee58f476a535222ee23f16649b4d58b4bb6a2530d05d04fc343778951d689d3L150-R150): Added `'crates.io-index'` to the `cdn_mirror_list` to support indexing for the Rust package registry.