### PR TITLE
修复列表表头错误

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
@@ -120,8 +120,8 @@
     const headers = table.querySelectorAll('th');
     if (headers.length >= 3) {
         headers[0].innerHTML = '<svg width="18" height="18" style="vertical-align: middle; margin-right: 4px;" fill="currentColor" viewBox="0 0 20 20"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg> 文件名';
-        headers[1].innerHTML = '<svg width="18" height="18" style="vertical-align: middle; margin-right: 4px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/></svg> 修改时间';
-        headers[2].innerHTML = '<svg width="18" height="18" style="vertical-align: middle; margin-right: 4px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/></svg> 大小';
+        headers[1].innerHTML = '<svg width="18" height="18" style="vertical-align: middle; margin-right: 4px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/></svg> 大小';
+        headers[2].innerHTML = '<svg width="18" height="18" style="vertical-align: middle; margin-right: 4px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/></svg> 修改时间';
     }
     
     // Add performance indicator for large directories


### PR DESCRIPTION
This pull request updates the order of the table headers in the `footer.html` file to display "大小" (Size) as the second column and "修改时间" (Last Modified) as the third column, swapping their previous positions. The associated SVG icons are also updated to match the new order.

UI/UX improvements:

* Swapped the "大小" (Size) and "修改时间" (Last Modified) table headers, including their SVG icons, so that "大小" now appears as the second column and "修改时间" as the third column. (`Nginx-Fancyindex-Theme/gdut-mirrors/footer.html`)