### PR TITLE
Add cache acceleration for Fedora

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -292,7 +292,7 @@ html = HEADER
 odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
-cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse']
+cdn_mirror_list = ['pypi', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora']
 ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme', 'certs', 'git', 'scripts', 'ubuntu-cloud-images']
 
 for mirror in mirror_list:

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -11,6 +11,8 @@ proxy_cache_path /home/mirror/nginx_cache/centos-vault levels=2:2 keys_zone=cach
 proxy_cache_path /home/mirror/nginx_cache/debian levels=2:2 keys_zone=cache_debian:1m max_size=5G inactive=30d use_temp_path=off;
 # epel （非x86_64）缓存
 proxy_cache_path /home/mirror/nginx_cache/epel levels=2:2 keys_zone=cache_epel:1m max_size=5G inactive=30d use_temp_path=off;
+# fedora 缓存
+proxy_cache_path /home/mirror/nginx_cache/fedora levels=2:2 keys_zone=cache_fedora:2m max_size=10G inactive=2h use_temp_path=off;
 # freebsd-pkg 缓存
 proxy_cache_path /home/mirror/nginx_cache/freebsd-pkg levels=2:2 keys_zone=cache_freebsd_pkg:2m max_size=10G inactive=2h use_temp_path=off;
 # gentoo （distfiles）缓存【自动预热】
@@ -202,6 +204,30 @@ server {
     location @epel_2h_tuna_tsinghua {
         include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_epel;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
+    # fedora 缓存配置
+    ##############################
+
+    # 检测到文件不存在则反代到清华
+    location /fedora/ {
+        try_files $uri $uri/ @fedora_tuna_tsinghua;
+    }
+    location ~ /fedora/($|.*/$) {
+        try_files $uri $uri/ @fedora_2h_tuna_tsinghua;
+    }
+    # 普通文件 缓存30天
+    location @fedora_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_fedora;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 目录 缓存2小时
+    location @fedora_2h_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_fedora;
         include /home/nginx/conf/mirror/cache_2h.conf;
     }
 


### PR DESCRIPTION
This pull request adds support for caching and proxying Fedora mirror files, both in the backend Python script and in the Nginx configuration. The main changes introduce Fedora to the list of CDN mirrors, set up a dedicated cache for Fedora files, and define new Nginx locations and caching behaviors for Fedora content.

**Fedora mirror support:**

* Added `'fedora'` to the `cdn_mirror_list` in `mirror_index.py`, enabling the backend to recognize and handle Fedora as a CDN mirror.

**Nginx configuration for Fedora:**

* Defined a new cache path for Fedora in the Nginx configuration, allocating 2MB of cache space, a maximum size of 10GB, and a 2-hour inactive timeout in `mirror.conf`.
* Added a new Nginx location block for `/fedora/` to proxy and cache Fedora files, with logic to differentiate between regular files (cached for 30 days) and directories (cached for 2 hours), and to fallback to Tsinghua Tuna mirror when files are missing.