### PR TITLE
修正顶栏 brand 显示时机：改为 Hero 标题滚到顶栏后面时触发

### DIFF
--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -229,10 +229,12 @@
     // ==========================================
 
     function initNavbarBrandVisibility() {
-        const hero = document.querySelector('.hero');
+        const heroTitle = document.querySelector('.hero-title');
+        const navbar = document.querySelector('.navbar');
         const navbarBrand = document.querySelector('.navbar-brand');
-        if (!hero || !navbarBrand) return;
+        if (!heroTitle || !navbarBrand || !navbar) return;
 
+        const navbarHeight = navbar.offsetHeight;
         const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
@@ -242,10 +244,11 @@
                 }
             });
         }, {
+            rootMargin: `-${navbarHeight}px 0px 0px 0px`,
             threshold: 0,
         });
 
-        observer.observe(hero);
+        observer.observe(heroTitle);
     }
 
     // ==========================================


### PR DESCRIPTION
## 问题
#59 的实现中，顶栏 brand 的显示时机过晚——使用了 `threshold: 0` 观察整个 `.hero` 元素，导致只有 Hero **完全**离开视口时 brand 才出现。

## 修复
改为观察 `.hero-title`（标题元素），并用 `rootMargin` 负 top 值将观察区域顶部下移到 navbar 底部：

- **观察目标**：`.hero` → `.hero-title`（标题）
- **rootMargin**：`-px 0px 0px 0px`（动态测量 navbar 高度）
- **效果**：当标题滚到 navbar 后面时 brand 立即出现，而非等整个 Hero 消失

## 涉及文件
- `pages/mirror.js` — `initNavbarBrandVisibility()` 观察目标与 rootMargin 调整