### PR TITLE
修复 FancyIndex 目录文件过少时底栏飘起问题

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
@@ -8,6 +8,16 @@
     <link rel="icon" type="image/x-icon" href="/Nginx-Fancyindex-Theme/gdut-mirrors/favicon.ico">
     <title>目录浏览 - 广东工业大学开源镜像站</title>
     <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        .main-container {
+            flex: 1;
+        }
+
         /* Additional styles for fancyindex directory listing */
         .fancyindex-list {
             width: 100%;


### PR DESCRIPTION
## 问题
FancyIndex 目录浏览页面中，当某路径下文件过少时，内容不足以撑满视口高度，导致 `<footer>` 跟在内容后面上浮，navbar 与 footer 之间出现大片空白。

## 修复
在 `header.html` 的内联 `<style>` 中添加 sticky footer 布局：
- `body` 设为 `display: flex; flex-direction: column; min-height: 100vh;`
- `.main-container` 设为 `flex: 1` 自动填充剩余空间，将 footer 推到视口底部

仅影响 FancyIndex 页面，不影响主页。

## 涉及文件
- `Nginx-Fancyindex-Theme/gdut-mirrors/header.html` — 内联样式添加 flex 布局