### PR TITLE
修复 FancyIndex 目录文件过少时底栏飘起问题

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -108,6 +108,8 @@ body {
         radial-gradient(at 0% 0%, rgba(151, 25, 67, 0.05) 0px, transparent 50%),
         radial-gradient(at 100% 100%, rgba(151, 25, 67, 0.05) 0px, transparent 50%);
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -343,8 +345,10 @@ a:hover {
 
 .main-container {
     max-width: 1400px;
+    width: 100%;
     margin: 0 auto;
     padding: var(--spacing-2xl) var(--spacing-xl);
+    flex: 1;
 }
 
 .bento-grid {


### PR DESCRIPTION
## 问题
FancyIndex 目录浏览页在文件/目录数量较少时，底栏（footer）会浮在内容下方而非贴在视口底部。

## 修复
采用经典 sticky footer 布局：

- `body` 添加 `display: flex; flex-direction: column;`
- `.main-container` 添加 `flex: 1; width: 100%;`

这样 `<main>` 会自动撑满视口剩余高度，footer 始终贴在底部。

## 涉及文件
- `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css` — body 和 .main-container 布局