### PR TITLE
统一主页与 FancyIndex 的 mirror.css/mirror.js

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
@@ -7,17 +7,8 @@
     <link rel="stylesheet" type="text/css" href="/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css" media="screen" />
     <link rel="icon" type="image/x-icon" href="/Nginx-Fancyindex-Theme/gdut-mirrors/favicon.ico">
     <title>目录浏览 - 广东工业大学开源镜像站</title>
+    <script>document.documentElement.classList.add('js');</script>
     <style>
-        body {
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
-        .main-container {
-            flex: 1;
-        }
-
         /* Additional styles for fancyindex directory listing */
         .fancyindex-list {
             width: 100%;

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -231,6 +231,19 @@ a:hover {
     border-radius: var(--radius-sm);
 }
 
+html.js .navbar-brand.autohide {
+    transform: translateY(100%);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform var(--transition-slow), opacity var(--transition-slow);
+}
+
+html.js .navbar-brand.autohide.is-visible {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+}
+
 .navbar-actions {
     display: flex;
     align-items: center;
@@ -423,6 +436,7 @@ a:hover {
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--color-text);
+    margin: 0;
 }
 
 /* Compact Islands (Sidebar) */
@@ -432,7 +446,7 @@ a:hover {
 
 .island-compact .island-title {
     font-size: 1.125rem;
-    margin-bottom: var(--spacing-md);
+    margin: 0;
 }
 
 /* ==========================================

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -225,6 +225,33 @@
     }
 
     // ==========================================
+    // Navbar Brand Visibility
+    // ==========================================
+
+    function initNavbarBrandVisibility() {
+        const heroTitle = document.querySelector('.hero-title');
+        const navbar = document.querySelector('.navbar');
+        const navbarBrand = document.querySelector('.navbar-brand.autohide');
+        if (!heroTitle || !navbarBrand || !navbar) return;
+
+        const navbarHeight = navbar.offsetHeight;
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    navbarBrand.classList.remove('is-visible');
+                } else {
+                    navbarBrand.classList.add('is-visible');
+                }
+            });
+        }, {
+            rootMargin: `-${navbarHeight}px 0px 0px 0px`,
+            threshold: 0,
+        });
+
+        observer.observe(heroTitle);
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -234,6 +261,7 @@
         initIslandAnimations();
         enhanceTable();
         initSmoothScroll();
+        initNavbarBrandVisibility();
         
         // Add fade-in class to body
         document.body.classList.add('fade-in');

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -27,7 +27,7 @@ HEADER = """
 <!-- Glassmorphic Navigation Bar -->
 <nav class="navbar">
     <div class="navbar-container">
-        <a href="/" class="navbar-brand">
+        <a href="/" class="navbar-brand autohide">
             <img src="/GDUT_Logo.png" alt="GDUT Logo">
             <span>广东工业大学开源镜像站</span>
         </a>

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -108,6 +108,8 @@ body {
         radial-gradient(at 0% 0%, rgba(151, 25, 67, 0.05) 0px, transparent 50%),
         radial-gradient(at 100% 100%, rgba(151, 25, 67, 0.05) 0px, transparent 50%);
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
@@ -229,14 +231,14 @@ a:hover {
     border-radius: var(--radius-sm);
 }
 
-html.js .navbar-brand {
+html.js .navbar-brand.autohide {
     transform: translateY(100%);
     opacity: 0;
     pointer-events: none;
     transition: transform var(--transition-slow), opacity var(--transition-slow);
 }
 
-html.js .navbar-brand.is-visible {
+html.js .navbar-brand.autohide.is-visible {
     transform: translateY(0);
     opacity: 1;
     pointer-events: auto;
@@ -356,8 +358,10 @@ html.js .navbar-brand.is-visible {
 
 .main-container {
     max-width: 1400px;
+    width: 100%;
     margin: 0 auto;
     padding: var(--spacing-2xl) var(--spacing-xl);
+    flex: 1;
 }
 
 .bento-grid {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -231,7 +231,7 @@
     function initNavbarBrandVisibility() {
         const heroTitle = document.querySelector('.hero-title');
         const navbar = document.querySelector('.navbar');
-        const navbarBrand = document.querySelector('.navbar-brand');
+        const navbarBrand = document.querySelector('.navbar-brand.autohide');
         if (!heroTitle || !navbarBrand || !navbar) return;
 
         const navbarHeight = navbar.offsetHeight;


### PR DESCRIPTION
## 背景
主页（`pages/`）和 FancyIndex（`Nginx-Fancyindex-Theme/gdut-mirrors/`）各自维护一份 `mirror.css` 和 `mirror.js`，经 diff 对比发现差异极少，可以统一。

## 原有差异
**CSS（4 处）**：
1. FancyIndex 独有：`body { display: flex; flex-direction: column }`（sticky footer 修复）
2. FancyIndex 独有：`.main-container { width: 100%; flex: 1 }`（sticky footer 修复）
3. 主页独有：`html.js .navbar-brand` 滚动可见性样式
4. `.island-compact .island-title` margin 值不同

**JS（1 处）**：
1. 主页独有：`initNavbarBrandVisibility()` 函数

## 统一方案
1. 以主页版本为基准，合入 FancyIndex 的 sticky footer 修复（body flex + .main-container flex:1）
2. navbar-brand 滚动可见性 CSS 选择器从 `html.js .navbar-brand` 改为 `html.js .navbar-brand.autohide`
3. JS 中 `initNavbarBrandVisibility()` 查找改为 `.navbar-brand.autohide`
4. 主页 `mirror_index.py` 的 navbar-brand 加 `autohide` class
5. FancyIndex `header.html` 加 inline script（`html.js` 类）保持一致，但 navbar-brand **不加** `autohide`，不受滚动隐藏影响
6. 统一后的 `mirror.css` 和 `mirror.js` 复制到两个目录，内容完全一致

## 涉及文件
- `pages/mirror.css` — 合入 sticky footer，navbar-brand 选择器改 .autohide
- `pages/mirror.js` — 查找改 .navbar-brand.autohide
- `mirror_index.py` — navbar-brand 加 autohide class
- `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css` — 统一为同一份
- `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js` — 统一为同一份
- `Nginx-Fancyindex-Theme/gdut-mirrors/header.html` — 加 inline script