### PR TITLE
增强 Island hover 浮起效果，版权年份改为动态获取

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
@@ -60,7 +60,7 @@
         </a>
     </div>
     <div style="margin-top: 12px; font-size: 0.875rem; color: var(--color-text-muted);">
-        © 2024 广东工业大学学生网管队 | Powered by Island UI & Nginx Fancy Index
+        © <span id="copyright-year"></span> 广东工业大学学生网管队 | Powered by Island UI & Nginx Fancy Index
     </div>
 </footer>
 

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -413,6 +413,7 @@ html.js .navbar-brand.autohide.is-visible {
 .island:hover {
     transform: translateY(-4px);
     box-shadow: var(--shadow-xl);
+    border-color: var(--color-primary);
 }
 
 .island:hover::before {

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -262,8 +262,10 @@
         enhanceTable();
         initSmoothScroll();
         initNavbarBrandVisibility();
-        
-        // Add fade-in class to body
+
+        const yearSpan = document.getElementById('copyright-year');
+        if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+
         document.body.classList.add('fade-in');
     }
     

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -267,7 +267,7 @@ FOOTER = """
         </a>
     </div>
     <div style="margin-top: 12px; font-size: 0.875rem; color: var(--color-text-muted);">
-        © 2024 广东工业大学学生网管队 | Powered by Island UI
+        © <span id="copyright-year"></span> 广东工业大学学生网管队 | Powered by Island UI
     </div>
 </footer>
 

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -413,6 +413,7 @@ html.js .navbar-brand.autohide.is-visible {
 .island:hover {
     transform: translateY(-4px);
     box-shadow: var(--shadow-xl);
+    border-color: var(--color-primary);
 }
 
 .island:hover::before {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -262,8 +262,10 @@
         enhanceTable();
         initSmoothScroll();
         initNavbarBrandVisibility();
-        
-        // Add fade-in class to body
+
+        const yearSpan = document.getElementById('copyright-year');
+        if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+
         document.body.classList.add('fade-in');
     }
     


### PR DESCRIPTION
## 变更内容

### 1. Island hover 浮起效果增强
参考文档站和容器镜像库的交互效果，为所有 island 增强 hover 浮起：
- transform: translateY(-4px) 上浮
- box-shadow: var(--shadow-xl) 放大阴影
- border-color: var(--color-primary) 边框变主题色（新增）
- ::before 顶部渐变条显示

主页和 FancyIndex 的所有岛均生效。

### 2. 版权年份改为 JS 动态获取
© 2024 改为 span，JS 自动填充 new Date().getFullYear()，无需手动更新。

### 涉及文件
- pages/mirror.css — island hover 增强
- mirror_index.py — 主页版权文本
- Nginx-Fancyindex-Theme/gdut-mirrors/footer.html — FancyIndex 版权文本
- pages/mirror.js — 年份填充逻辑
- FancyIndex 目录 CSS/JS 同步