### PR TITLE
修复 Island hover 浮起不生效，搜索框添加 hover 效果

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -323,6 +323,12 @@ html.js .navbar-brand.autohide.is-visible {
 .search-box {
     position: relative;
     width: 100%;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.search-box:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
 }
 
 .search-input {

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -128,12 +128,17 @@
     function initIslandAnimations() {
         const islands = document.querySelectorAll('.island');
         
-        // Intersection Observer for scroll animations
         const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
                     entry.target.style.opacity = '1';
                     entry.target.style.transform = 'translateY(0)';
+                    entry.target.addEventListener('transitionend', function handler() {
+                        entry.target.style.transform = '';
+                        entry.target.style.transition = '';
+                        entry.target.removeEventListener('transitionend', handler);
+                    });
+                    observer.unobserve(entry.target);
                 }
             });
         }, {

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -323,6 +323,12 @@ html.js .navbar-brand.autohide.is-visible {
 .search-box {
     position: relative;
     width: 100%;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.search-box:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
 }
 
 .search-input {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -128,12 +128,17 @@
     function initIslandAnimations() {
         const islands = document.querySelectorAll('.island');
         
-        // Intersection Observer for scroll animations
         const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
                     entry.target.style.opacity = '1';
                     entry.target.style.transform = 'translateY(0)';
+                    entry.target.addEventListener('transitionend', function handler() {
+                        entry.target.style.transform = '';
+                        entry.target.style.transition = '';
+                        entry.target.removeEventListener('transitionend', handler);
+                    });
+                    observer.unobserve(entry.target);
                 }
             });
         }, {


### PR DESCRIPTION
## 问题
上一 PR (#66) 中添加了 `transform: translateY(-4px)` 的 island hover 浮起效果，但实际不生效。

## 根因
`mirror.js` 的 `initIslandAnimations()` 在 IntersectionObserver 回调中设置了内联 `style.transform = 'translateY(0)'`，内联样式优先级高于 CSS `:hover` 伪类，导致 hover 时 transform 始终为 `translateY(0)` 而非 `translateY(-4px)`。

## 修复
### 1. Island hover 浮起修复
在 `transitionend` 事件回调中清除内联 `transform` 和 `transition`，让 CSS `:hover` 接管：
```js
entry.target.addEventListener('transitionend', function handler() {
    entry.target.style.transform = '';
    entry.target.style.transition = '';
    entry.target.removeEventListener('transitionend', handler);
});
```

### 2. 搜索框 hover 效果
给 `.search-box` 添加 hover 浮起（translateY(-2px) + shadow-lg），与 island 风格一致。

### 涉及文件
- `pages/mirror.js` — initIslandAnimations 修复
- `pages/mirror.css` — search-box hover 样式
- FancyIndex 目录 CSS/JS 同步