### PR TITLE
优化 FancyIndex 面包屑：圆角矩形包围、SVG 图标

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
@@ -74,37 +74,34 @@
 
     if (!breadcrumb) return;
 
-    // Create home link
+    const homeSvg = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>';
+
+    const homeItem = document.createElement('span');
+    homeItem.className = 'breadcrumb-item';
     const homeLink = document.createElement('a');
     homeLink.href = '/';
-    homeLink.textContent = '🏠 首页';
-    breadcrumb.appendChild(homeLink);
+    homeLink.innerHTML = homeSvg + ' 首页';
+    homeItem.appendChild(homeLink);
+    breadcrumb.appendChild(homeItem);
 
     let currentPath = '';
 
     parts.forEach((part, index) => {
         currentPath += '/' + part;
-        
-        // Add separator
-        const separator = document.createElement('span');
-        separator.className = 'breadcrumb-separator';
-        separator.textContent = '/';
-        breadcrumb.appendChild(separator);
-
         const decodedPart = decodeURIComponent(part);
-        
+
+        const item = document.createElement('span');
+        item.className = 'breadcrumb-item';
+
         if (index === parts.length - 1) {
-            // Last part - just text, no link
-            const span = document.createElement('span');
-            span.textContent = decodedPart;
-            breadcrumb.appendChild(span);
+            item.textContent = decodedPart;
         } else {
-            // Create link for intermediate parts
             const link = document.createElement('a');
             link.href = currentPath + '/';
             link.textContent = decodedPart;
-            breadcrumb.appendChild(link);
+            item.appendChild(link);
         }
+        breadcrumb.appendChild(item);
     });
 })();
 

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
@@ -74,25 +74,49 @@
 
         /* Breadcrumb navigation */
         .breadcrumb {
-            display: flex;
+            display: inline-flex;
             align-items: center;
-            gap: var(--spacing-sm);
-            padding: var(--spacing-md) 0;
-            color: var(--color-text-secondary);
-            font-size: 0.9375rem;
+            padding: var(--spacing-xs) var(--spacing-md);
+            margin-bottom: var(--spacing-lg);
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-sm);
+            font-size: 1.0625rem;
+            flex-wrap: wrap;
         }
 
-        .breadcrumb a {
-            color: var(--color-primary);
-            text-decoration: none;
+        .breadcrumb-item {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-xs);
         }
 
-        .breadcrumb a:hover {
-            text-decoration: underline;
-        }
-
-        .breadcrumb-separator {
+        .breadcrumb-item:not(:last-child)::after {
+            content: '|';
+            margin: 0 var(--spacing-xs);
             color: var(--color-text-muted);
+            opacity: 0.4;
+            font-weight: 400;
+        }
+
+        .breadcrumb-item svg {
+            vertical-align: middle;
+            flex-shrink: 0;
+        }
+
+        .breadcrumb-item a {
+            color: var(--color-text-muted);
+            text-decoration: none;
+            transition: color var(--transition-fast);
+        }
+
+        .breadcrumb-item a:hover {
+            color: var(--color-primary);
+        }
+
+        .breadcrumb-item:last-child {
+            color: var(--color-text);
+            font-weight: 500;
         }
         
         /* Fade-in animation for search results */


### PR DESCRIPTION
## 变更内容

参考 docker-registry-browser 的面包屑设计，优化 FancyIndex 目录浏览的路径导航：

### 1. 圆角矩形包围
面包屑从无边框改为圆角矩形卡片样式：
- `background: var(--color-surface)` 背景
- `border: 1px solid var(--color-border)` 边框
- `border-radius: var(--radius-sm)` 圆角
- `padding` 内边距

### 2. 分隔符改为 |
从 `/` 改为 `|`，用 `::after` 伪元素实现，最后一项无分隔符。

### 3. 首页 Emoji 换 SVG 图标
`🏠 首页` 换成 Lucide 风格 home SVG 图标（与镜像站其他 SVG 图标风格一致）：
`<svg><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg> 首页`

### 4. DOM 结构优化
每项用 `<span class="breadcrumb-item">` 包裹，CSS 用 `::after` 伪元素生成分隔符，不再手动创建 separator span。

### 效果
`[🏠 首页 | ubuntu | pool | main]`（圆角矩形包围，| 分隔）

### 涉及文件
- `Nginx-Fancyindex-Theme/gdut-mirrors/header.html` — 面包屑 CSS
- `Nginx-Fancyindex-Theme/gdut-mirrors/footer.html` — 面包屑 JS