### PR TITLE
修复面包屑首页图标对齐 + 隐藏 Nginx 路径文本

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/footer.html
@@ -66,6 +66,20 @@
 
 <script type="text/javascript" src="/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js"></script>
 <script>
+// Remove Nginx-generated path text from fancyindex-list (CSS display:none may not catch bare text nodes)
+(function() {
+    const list = document.querySelector('.fancyindex-list');
+    if (!list) return;
+    const table = list.querySelector('table');
+    if (!table) return;
+    let node = list.firstChild;
+    while (node && node !== table) {
+        const next = node.nextSibling;
+        list.removeChild(node);
+        node = next;
+    }
+})();
+
 // Generate breadcrumb navigation from current path
 (function() {
     const path = window.location.pathname;

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
@@ -105,6 +105,9 @@
         }
 
         .breadcrumb-item a {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-xs);
             color: var(--color-text-muted);
             text-decoration: none;
             transition: color var(--transition-fast);


### PR DESCRIPTION
## 修复内容

### 1. 面包屑首页 SVG 图标与文字未对齐

**原因**：`homeLink.innerHTML = homeSvg + ' 首页'` 将 SVG 和文字作为 inline 内容放在 `<a>` 内，`.breadcrumb-item` 的 `align-items: center` 只作用于 `<a>` 元素本身，`<a>` 内部的 SVG 和文字没有 flex 对齐。

**修复**：给 `.breadcrumb-item a` 添加 `display: inline-flex; align-items: center; gap: var(--spacing-xs)`，使 `<a>` 内部的 SVG 和文字也走 flex 布局垂直居中。

### 2. Nginx 生成的路径文本与面包屑重复

**问题**：Nginx Fancy Index 在 `<div class="fancyindex-list">` 和 `<table>` 之间输出当前路径文本（如 `/ubuntu/pool/main/`），与 JS 生成的面包屑导航重复。已有 CSS `.fancyindex-list > h1 { display: none }` 但未生效（Nginx 输出的可能是裸文本节点而非 `<h1>` 元素）。

**修复**：在 `footer.html` 的 `<script>` 开头添加 JS，遍历 `.fancyindex-list` 的子节点，删除 `<table>` 之前的所有节点（包括 `<h1>` 元素和裸文本节点），确保路径文本被彻底移除。

### 涉及文件
- `Nginx-Fancyindex-Theme/gdut-mirrors/header.html` — `.breadcrumb-item a` CSS
- `Nginx-Fancyindex-Theme/gdut-mirrors/footer.html` — 路径文本删除 JS