### PR TITLE
修复健康分进度条 + 分区表添加使用率进度条

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -143,11 +143,14 @@
             border-radius: 3px;
             overflow: hidden;
         }
-        .health-fill { height: 100%; border-radius: 3px; transition: width var(--transition-base); }
+        .health-fill { display: block; height: 100%; border-radius: 3px; transition: width var(--transition-base); }
         .pct-tag { font-weight: 600; }
         .pct-good { color: var(--color-success); }
         .pct-warn { color: var(--color-warning); }
         .pct-crit { color: var(--color-error); }
+        .usage-cell { display: flex; flex-direction: column; gap: 4px; min-width: 120px; }
+        .usage-bar-track { width: 100%; height: 8px; background: var(--color-border); border-radius: 4px; overflow: hidden; }
+        .usage-bar-fill { display: block; height: 100%; border-radius: 4px; transition: width var(--transition-base); }
 
         /* Charts */
         .chart-grid {
@@ -556,6 +559,26 @@
         if (p >= 65) return '#f59e0b';
         return '#10b981';
     }
+    function usageGradientColor(p) {
+        p = Math.max(0, Math.min(100, Number(p)));
+        var stops = [
+            { v: 0,   r: 16,  g: 185, b: 129 },
+            { v: 50,  r: 245, g: 158, b: 11  },
+            { v: 70,  r: 249, g: 115, b: 22  },
+            { v: 85,  r: 239, g: 68,  b: 68  },
+            { v: 100, r: 239, g: 68,  b: 68  }
+        ];
+        for (var i = 0; i < stops.length - 1; i++) {
+            if (p >= stops[i].v && p <= stops[i + 1].v) {
+                var t = (p - stops[i].v) / (stops[i + 1].v - stops[i].v);
+                var r = Math.round(stops[i].r + (stops[i + 1].r - stops[i].r) * t);
+                var g = Math.round(stops[i].g + (stops[i + 1].g - stops[i].g) * t);
+                var b = Math.round(stops[i].b + (stops[i + 1].b - stops[i].b) * t);
+                return 'rgb(' + r + ',' + g + ',' + b + ')';
+            }
+        }
+        return 'rgb(239,68,68)';
+    }
 
     /* ===== CSS var helper ===== */
     function cssVar(name) {
@@ -899,12 +922,14 @@
                     const host = HOSTS[r.instance];
                     if (!host) return;
                     const u = isFinite(r.usage) ? r.usage : NaN;
+                    var uClamped = Math.max(0, Math.min(100, isFinite(u) ? u : 0));
                     html += '<tr>'
                         + '<td class="col-site">' + host.name + '</td>'
                         + '<td>' + (r.mountpoint || '-') + '</td>'
                         + '<td>' + fmtBytes(r.total) + '</td>'
                         + '<td>' + fmtBytes(r.avail) + '</td>'
-                        + '<td class="pct-tag ' + pctClass(u) + '">' + fmtPct(u) + '</td>'
+                        + '<td><div class="usage-cell"><span class="pct-tag ' + pctClass(u) + '">' + fmtPct(u) + '</span>'
+                        + '<div class="usage-bar-track"><span class="usage-bar-fill" style="width:' + uClamped.toFixed(1) + '%;background:' + usageGradientColor(uClamped) + ';"></span></div></div></td>'
                         + '</tr>';
                 });
         });


### PR DESCRIPTION
## 修复内容

### 1. 健康分进度条不渲染

**问题**：资源总览表中健康分进度条宽度始终为 0，但数值显示正常。

**原因**：`.health-fill` 是 `<span>`（inline 元素），CSS 只设了 `height: 100%` 但没设 `display: block`，inline 元素忽略 `width` 和 `height` 属性，导致进度条不渲染。

**修复**：`.health-fill` 添加 `display: block`。

### 2. 分区可用空间表添加使用率进度条

**需求**：分区表每行使用率列添加横向进度条，颜色按使用率从绿→黄→橙→红渐变。

**实现**：
- 使用率单元格改为 flex column 布局，文字在上进度条在下，互不影响
- 新增 `usageGradientColor()` 函数，按使用率百分比在 5 个色标间线性插值：
  - 0% → 绿色 (#10b981)
  - 50% → 黄色 (#f59e0b)
  - 70% → 橙色 (#f97316)
  - 85% → 红色 (#ef4444)
  - 100% → 红色 (#ef4444)

### 涉及文件
- `pages/status.html` — CSS + JS