### PR TITLE
分区表进度条改为整行背景 + 伸展动画

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -148,9 +148,7 @@
         .pct-good { color: var(--color-success); }
         .pct-warn { color: var(--color-warning); }
         .pct-crit { color: var(--color-error); }
-        .usage-cell { display: flex; flex-direction: column; gap: 4px; min-width: 120px; }
-        .usage-bar-track { width: 100%; height: 8px; background: var(--color-border); border-radius: 4px; overflow: hidden; }
-        .usage-bar-fill { display: block; height: 100%; border-radius: 4px; transition: width var(--transition-base); }
+        .partition-row > td { background: transparent !important; }
 
         /* Charts */
         .chart-grid {
@@ -923,17 +921,38 @@
                     if (!host) return;
                     const u = isFinite(r.usage) ? r.usage : NaN;
                     var uClamped = Math.max(0, Math.min(100, isFinite(u) ? u : 0));
-                    html += '<tr>'
+                    var barColor = usageGradientColor(uClamped);
+                    html += '<tr class="partition-row" data-bar-w="' + uClamped.toFixed(1) + '" data-bar-c="' + barColor + '">'
                         + '<td class="col-site">' + host.name + '</td>'
                         + '<td>' + (r.mountpoint || '-') + '</td>'
                         + '<td>' + fmtBytes(r.total) + '</td>'
                         + '<td>' + fmtBytes(r.avail) + '</td>'
-                        + '<td><div class="usage-cell"><span class="pct-tag ' + pctClass(u) + '">' + fmtPct(u) + '</span>'
-                        + '<div class="usage-bar-track"><span class="usage-bar-fill" style="width:' + uClamped.toFixed(1) + '%;background:' + usageGradientColor(uClamped) + ';"></span></div></div></td>'
+                        + '<td class="pct-tag ' + pctClass(u) + '">' + fmtPct(u) + '</td>'
                         + '</tr>';
                 });
         });
         document.getElementById('partition-tbody').innerHTML = html;
+        // Animate progress bars from left to right
+        var barRows = document.querySelectorAll('#partition-tbody .partition-row');
+        barRows.forEach(function (tr) {
+            var targetW = parseFloat(tr.dataset.barW) || 0;
+            var color = tr.dataset.barC || 'transparent';
+            var tds = tr.querySelectorAll('td');
+            if (!tds.length) return;
+            var startTime = null;
+            function step(ts) {
+                if (!startTime) startTime = ts;
+                var progress = Math.min((ts - startTime) / 600, 1);
+                var eased = 1 - Math.pow(1 - progress, 3);
+                var curW = targetW * eased;
+                var bg = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
+                for (var i = 0; i < tds.length; i++) {
+                    tds[i].style.background = bg;
+                }
+                if (progress < 1) requestAnimationFrame(step);
+            }
+            requestAnimationFrame(step);
+        });
     }
 
     /* ===== Panel 5: CPU timeseries ===== */


### PR DESCRIPTION
## 改动

重新实现分区可用空间表的使用率进度条：

### 之前的问题
- 进度条只在使用率列内显示（一个小条），没有填满整行
- 没有伸展动画

### 现在
- **整行背景层**：用 `linear-gradient` 设到每个 `<td>` 的 background 上，进度条填满整行宽度
- **文字在上层**：进度条透明度 0.18，文字正常显示不受影响
- **颜色渐变**：按使用率从绿(0%)→黄(50%)→橙(70%)→红(85%+)连续变化
- **伸展动画**：加载时用 `requestAnimationFrame` 实现 600ms 从左到右展开（cubic ease-out）

### 涉及文件
- `pages/status.html`