### PR TITLE
修复分区表进度条不显示

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -148,7 +148,6 @@
         .pct-good { color: var(--color-success); }
         .pct-warn { color: var(--color-warning); }
         .pct-crit { color: var(--color-error); }
-        .partition-row > td { background: transparent !important; }
 
         /* Charts */
         .chart-grid {


### PR DESCRIPTION
## 修复

**问题**：分区表进度条完全不显示。

**原因**：CSS 规则 `.partition-row > td { background: transparent !important; }` 中的 `!important` 优先级高于 JS 通过 `tds[i].style.background = bg` 设置的内联样式，把进度条背景强制覆盖为透明。

**修复**：移除该 CSS 规则。JS 设置的 `linear-gradient` 内联背景不再被覆盖，进度条正常显示。

### 涉及文件
- `pages/status.html`