### PR TITLE
修复分区表进度条：改为整行单个进度条

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -148,6 +148,7 @@
         .pct-good { color: var(--color-success); }
         .pct-warn { color: var(--color-warning); }
         .pct-crit { color: var(--color-error); }
+        .partition-row > td { background-color: transparent; }
 
         /* Charts */
         .chart-grid {
@@ -936,18 +937,13 @@
         barRows.forEach(function (tr) {
             var targetW = parseFloat(tr.dataset.barW) || 0;
             var color = tr.dataset.barC || 'transparent';
-            var tds = tr.querySelectorAll('td');
-            if (!tds.length) return;
             var startTime = null;
             function step(ts) {
                 if (!startTime) startTime = ts;
                 var progress = Math.min((ts - startTime) / 600, 1);
                 var eased = 1 - Math.pow(1 - progress, 3);
                 var curW = targetW * eased;
-                var bg = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
-                for (var i = 0; i < tds.length; i++) {
-                    tds[i].style.background = bg;
-                }
+                tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
                 if (progress < 1) requestAnimationFrame(step);
             }
             requestAnimationFrame(step);


### PR DESCRIPTION
## 修复

**问题**：每个 `<td>` 各设 `linear-gradient`，百分比相对各自 `<td>` 宽度计算，导致各列进度条长度不一致，看起来像每列一个进度条。

**修复**：`linear-gradient` 改为设在 `<tr>` 上（相对整行宽度计算），`<td>` 保持 `background-color: transparent`（不带 `!important`，避免覆盖 JS）。视觉上是一整行一个进度条。

### 涉及文件
- `pages/status.html`