### PR TITLE
修复分区表进度条伸展动画不播放

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -937,16 +937,23 @@
         barRows.forEach(function (tr) {
             var targetW = parseFloat(tr.dataset.barW) || 0;
             var color = tr.dataset.barC || 'transparent';
-            var startTime = null;
-            function step(ts) {
-                if (!startTime) startTime = ts;
-                var progress = Math.min((ts - startTime) / 600, 1);
-                var eased = 1 - Math.pow(1 - progress, 3);
-                var curW = targetW * eased;
-                tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
-                if (progress < 1) requestAnimationFrame(step);
-            }
-            requestAnimationFrame(step);
+            // Set initial 0% state and force browser to paint it first
+            tr.style.background = 'linear-gradient(90deg, ' + color + ' 0%, transparent 0%)';
+            void tr.offsetWidth; // force reflow
+            // Double rAF: ensures browser paints 0% frame before animation starts
+            requestAnimationFrame(function () {
+                requestAnimationFrame(function anim(ts) {
+                    var startTime = ts;
+                    function step(t) {
+                        var progress = Math.min((t - startTime) / 600, 1);
+                        var eased = 1 - Math.pow(1 - progress, 3);
+                        var curW = targetW * eased;
+                        tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
+                        if (progress < 1) requestAnimationFrame(step);
+                    }
+                    requestAnimationFrame(step);
+                });
+            });
         });
     }
 


### PR DESCRIPTION
## 修复

**问题**：进度条显示正常但没有从 0% 到目标值的伸展动画。

**原因**：`innerHTML` 设置后，浏览器还没渲染 0% 初始状态，`requestAnimationFrame` 就已开始跑动画，浏览器跳过中间帧直接绘制了最终状态。

**修复**：
1. 先设置 0% 初始状态
2. `void tr.offsetWidth` 强制 reflow，让浏览器立即布局
3. 双 `requestAnimationFrame` 确保浏览器先绘制 0% 帧再开始动画

### 涉及文件
- `pages/status.html`