### PR TITLE
修复分区表进度条动画：等 Island 可见后再播放

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -932,29 +932,47 @@
                 });
         });
         document.getElementById('partition-tbody').innerHTML = html;
-        // Animate progress bars from left to right
+        // Animate progress bars from left to right, but only after island is visible
+        var island = document.getElementById('partition-tbody').closest('.island');
         var barRows = document.querySelectorAll('#partition-tbody .partition-row');
+        // Set initial 0% state immediately
         barRows.forEach(function (tr) {
-            var targetW = parseFloat(tr.dataset.barW) || 0;
             var color = tr.dataset.barC || 'transparent';
-            // Set initial 0% state and force browser to paint it first
             tr.style.background = 'linear-gradient(90deg, ' + color + ' 0%, transparent 0%)';
-            void tr.offsetWidth; // force reflow
-            // Double rAF: ensures browser paints 0% frame before animation starts
-            requestAnimationFrame(function () {
-                requestAnimationFrame(function anim(ts) {
-                    var startTime = ts;
-                    function step(t) {
-                        var progress = Math.min((t - startTime) / 600, 1);
-                        var eased = 1 - Math.pow(1 - progress, 3);
-                        var curW = targetW * eased;
-                        tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
-                        if (progress < 1) requestAnimationFrame(step);
-                    }
-                    requestAnimationFrame(step);
-                });
-            });
         });
+
+        function runBarAnimation() {
+            barRows.forEach(function (tr) {
+                var targetW = parseFloat(tr.dataset.barW) || 0;
+                var color = tr.dataset.barC || 'transparent';
+                var startTime = null;
+                function step(ts) {
+                    if (!startTime) startTime = ts;
+                    var progress = Math.min((ts - startTime) / 1200, 1);
+                    var eased = 1 - Math.pow(1 - progress, 3);
+                    var curW = targetW * eased;
+                    tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
+                    if (progress < 1) requestAnimationFrame(step);
+                }
+                requestAnimationFrame(step);
+            });
+        }
+
+        if (island) {
+            var rect = island.getBoundingClientRect();
+            var alreadyVisible = rect.top < window.innerHeight && rect.bottom > 0;
+            if (alreadyVisible) {
+                runBarAnimation();
+            } else {
+                var visObs = new IntersectionObserver(function (entries) {
+                    if (entries[0].isIntersecting) {
+                        visObs.disconnect();
+                        runBarAnimation();
+                    }
+                }, { threshold: 0.1 });
+                visObs.observe(island);
+            }
+        }
     }
 
     /* ===== Panel 5: CPU timeseries ===== */


### PR DESCRIPTION
## 修复

**问题**：进度条伸展动画仍然看不到。

**原因**：分区表数据异步加载时，Island 本身还在 fadeIn 动画中（opacity:0），进度条动画在不可见状态下就跑完了，用户什么都看不到。

**修复**：
1. 用 `IntersectionObserver` 检测 Island 是否已进入视口
2. Island 不可见时只设 0% 初始状态，等可见后再启动动画
3. 动画时长从 600ms 放慢至 1200ms

### 涉及文件
- `pages/status.html`