### PR TITLE
修复分区表进度条动画：等 fadeIn 完成后触发

### DIFF
--- a/pages/status.html
+++ b/pages/status.html
@@ -932,7 +932,7 @@
                 });
         });
         document.getElementById('partition-tbody').innerHTML = html;
-        // Animate progress bars from left to right, but only after island is visible
+        // Animate progress bars from left to right, but only after island is visible and fadeIn complete
         var island = document.getElementById('partition-tbody').closest('.island');
         var barRows = document.querySelectorAll('#partition-tbody .partition-row');
         // Set initial 0% state immediately
@@ -942,36 +942,33 @@
         });
 
         function runBarAnimation() {
-            barRows.forEach(function (tr) {
+            barRows.forEach(function (tr, idx) {
                 var targetW = parseFloat(tr.dataset.barW) || 0;
                 var color = tr.dataset.barC || 'transparent';
-                var startTime = null;
-                function step(ts) {
-                    if (!startTime) startTime = ts;
-                    var progress = Math.min((ts - startTime) / 1200, 1);
-                    var eased = 1 - Math.pow(1 - progress, 3);
-                    var curW = targetW * eased;
-                    tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
-                    if (progress < 1) requestAnimationFrame(step);
-                }
-                requestAnimationFrame(step);
+                setTimeout(function () {
+                    var startTime = null;
+                    function step(ts) {
+                        if (!startTime) startTime = ts;
+                        var progress = Math.min((ts - startTime) / 1200, 1);
+                        var eased = 1 - Math.pow(1 - progress, 3);
+                        var curW = targetW * eased;
+                        tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
+                        if (progress < 1) requestAnimationFrame(step);
+                    }
+                    requestAnimationFrame(step);
+                }, idx * 150);
             });
         }
 
         if (island) {
-            var rect = island.getBoundingClientRect();
-            var alreadyVisible = rect.top < window.innerHeight && rect.bottom > 0;
-            if (alreadyVisible) {
-                runBarAnimation();
-            } else {
-                var visObs = new IntersectionObserver(function (entries) {
-                    if (entries[0].isIntersecting) {
-                        visObs.disconnect();
-                        runBarAnimation();
-                    }
-                }, { threshold: 0.1 });
-                visObs.observe(island);
-            }
+            var visObs = new IntersectionObserver(function (entries) {
+                if (entries[0].isIntersecting) {
+                    visObs.disconnect();
+                    // Wait for island fadeIn animation to finish before starting bar animation
+                    setTimeout(runBarAnimation, 700);
+                }
+            }, { threshold: 0.15 });
+            visObs.observe(island);
         }
     }
 


### PR DESCRIPTION
## 修复

**问题**：进度条动画仍然看不到，一出来就是最终状态。

**根因**：`mirror.js` 的 `initIslandAnimations` 给 island 设了 `opacity:0` + fadeIn 动画。但之前的代码用 `getBoundingClientRect` 检测 island 是否"已在视口内"——island 在 DOM 中存在但 opacity 还是 0 时，`getBoundingClientRect` 仍返回正常 rect，导致 `alreadyVisible` 为 true，动画在 island 还透明时就跑完了。

**修复**：
1. 去掉 `alreadyVisible` 立即执行路径，统一用 `IntersectionObserver(threshold:0.15)`
2. island 进入视口后延迟 700ms（等 fadeIn 动画 0.6s 完成）再启动进度条动画
3. 多行进度条逐行延迟 150ms 启动，形成从上到下的瀑布效果

### 涉及文件
- `pages/status.html`