### PR TITLE
修复 bargauge 刷新无动画

### DIFF
--- a/pages/status.js
+++ b/pages/status.js
@@ -186,7 +186,7 @@
         const c = getChart(id);
         if (!c) return;
         chartOpts[id] = option;
-        c.setOption(option, true);
+        c.setOption(option, false);
         const wrap = document.getElementById('wrap-' + id.replace('chart-', ''));
         if (wrap) wrap.classList.add('loaded');
     }
@@ -219,7 +219,7 @@
                 return;
             }
         }
-        showChartLoading(id);
+        if (!option.animationDuration) showChartLoading(id);
         setChart(id, option);
     }
     function matrixToSeries(result, nameFn, colorFn, yFmt) {


### PR DESCRIPTION
## 修复

**问题**：使用率概览（bargauge）60s 自动刷新时柱形图直接跳变，无过渡动画。

**根因**：
1. `setChart` 中 `setOption(option, true)` 的 `notMerge=true` 完全替换旧 option，ECharts 丢弃旧数据重新初始化系列，不做数据过渡动画
2. `renderChart` 非首次加载时强制走 `showChartLoading`（显示 loading 遮罩），遮盖了 ECharts 的动画

**修复**：
1. `setOption(option, false)` 改为合并模式，ECharts 做数据过渡动画
2. `renderChart` 中有 `animationDuration` 配置的图表刷新时不走 `showChartLoading`，直接 `setChart` 让 ECharts 做柱形过渡动画
3. 无 `animationDuration` 的折线图仍走 `showChartLoading` 转场

### 涉及文件
- `pages/status.js`