### PR TITLE
修复 bargauge 刷新无动画：刷新时不隐藏旧图表

### DIFF
--- a/pages/status.js
+++ b/pages/status.js
@@ -663,7 +663,7 @@
 
     /* ===== Panel 10: Bargauge ===== */
     async function loadBargauge() {
-        showChartLoading('chart-bargauge');
+        if (chartFirstLoad.has('chart-bargauge')) showChartLoading('chart-bargauge');
         const inst = instanceSelector();
         const iv = TIME_RANGES[state.range].interval;
         const T = {


### PR DESCRIPTION
## 修复

**问题**：bargauge 刷新时仍无过渡动画。

**根因**：`loadBargauge` 函数开头无条件调了 `showChartLoading`，把旧图表隐藏并显示 loading 遮罩。即使 `renderChart` 跳过了 loading，函数开头那个已经把旧图表藏掉了。旧数据被隐藏 → 新数据直接显示，ECharts 没有旧数据可以过渡。

**修复**：`showChartLoading` 改为仅首次加载时调用（`chartFirstLoad.has`）。刷新时保留旧图表，`setOption(option, false)` 合并模式让 ECharts 在新旧数据间做过渡动画。

### 涉及文件
- `pages/status.js`