### PR TITLE
修复使用率概览 CPU/iowait 无数据

### DIFF
--- a/pages/status.js
+++ b/pages/status.js
@@ -667,8 +667,8 @@
         const inst = instanceSelector();
         const iv = TIME_RANGES[state.range].interval;
         const T = {
-            cpu: '100 - (avg(irate(node_cpu_seconds_total{instance=~"' + inst + '",mode="idle"}[' + iv + '])) * 100)',
-            iowait: 'avg(irate(node_cpu_seconds_total{instance=~"' + inst + '",mode="iowait"}[' + iv + '])) * 100',
+            cpu: '100 - (avg(irate(node_cpu_seconds_total{instance=~"' + inst + '",mode="idle"}[' + iv + '])) by (instance) * 100)',
+            iowait: 'avg(irate(node_cpu_seconds_total{instance=~"' + inst + '",mode="iowait"}[' + iv + '])) by (instance) * 100',
             mem: '(1 - (node_memory_MemAvailable_bytes{instance=~"' + inst + '"} / node_memory_MemTotal_bytes{instance=~"' + inst + '"}))* 100',
             disk: '(node_filesystem_size_bytes{instance=~"' + inst + '",fstype=~"ext.*|xfs",mountpoint="/home"}-node_filesystem_free_bytes{instance=~"' + inst + '",fstype=~"ext.*|xfs",mountpoint="/home"})*100/(node_filesystem_avail_bytes{instance=~"' + inst + '",fstype=~"ext.*|xfs",mountpoint="/home"}+(node_filesystem_size_bytes{instance=~"' + inst + '",fstype=~"ext.*|xfs",mountpoint="/home"}-node_filesystem_free_bytes{instance=~"' + inst + '",fstype=~"ext.*|xfs",mountpoint="/home"}))',
             swap: '(1 - ((node_memory_SwapFree_bytes{instance=~"' + inst + '"} + 1)/ (node_memory_SwapTotal_bytes{instance=~"' + inst + '"} + 1))) * 100'


### PR DESCRIPTION
## 修复

**问题**：使用率概览（bargauge）只显示磁盘和内存，CPU、iowait、swap 无数据。

**根因**：CPU 和 iowait 的 PromQL 用了 `avg()` 但没有 `by (instance)` 分组，返回 `metric={}`（无 instance 标签）。JS 用 `r.metric.instance === inst2` 匹配 instance，但 metric 里没有 instance，匹配失败返回 0，柱形长度为 0。

**修复**：PromQL 加 `by (instance)`：
- CPU: `avg(irate(...)) by (instance) * 100`
- iowait: `avg(irate(...)) by (instance) * 100`

（swap 值为 0 是因为两台机器都没开 swap，属于正常数据）

### 涉及文件
- `pages/status.js`