### PR TITLE
强制统一时间按钮与下拉框高度为 39px

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -24,6 +24,8 @@
     border-radius: var(--radius-xl);
     padding: 4px;
     box-shadow: var(--shadow-sm);
+    height: 39px;
+    box-sizing: border-box;
 }
 .time-btn {
     border: none;
@@ -44,7 +46,7 @@
     box-shadow: var(--shadow-sm);
 }
 .site-selector {
-    padding: 7px 36px 7px 16px;
+    padding: 0 36px 0 16px;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-xl);
     background: var(--color-surface);
@@ -61,6 +63,8 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23718096' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
+    height: 39px;
+    box-sizing: border-box;
 }
 .site-selector:focus { border-color: var(--color-primary); }
 .refresh-indicator {


### PR DESCRIPTION
## 修复

时间按钮 39px，下拉框只有 33px。用 `height: 39px` + `box-sizing: border-box` 强制两者一致，select 的上下 padding 改为 0 让 height 完全控制。

### 涉及文件
- `pages/status.css`