### PR TITLE
总览 CPU/内存卡片添加背景面积图

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -84,6 +84,26 @@
     margin-bottom: var(--spacing-lg);
 }
 .stat-card { padding: var(--spacing-lg); }
+.stat-card.has-spark {
+    position: relative;
+    overflow: hidden;
+    padding-bottom: 48px;
+}
+.stat-card.has-spark .island-header,
+.stat-card.has-spark .stat-value,
+.stat-card.has-spark .stat-sub {
+    position: relative;
+    z-index: 1;
+}
+.stat-spark {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 42px;
+    z-index: 0;
+    pointer-events: none;
+}
 .stat-card .island-header { margin-bottom: var(--spacing-sm); }
 .stat-label {
     font-size: 0.8125rem;

--- a/pages/status.html
+++ b/pages/status.html
@@ -71,29 +71,33 @@
                     <div class="island-header"><span class="stat-label">IPv4 站点 · 状态</span></div>
                     <div class="stat-value" id="ov-ipv4-status">--</div>
                 </div>
-                <div class="island stat-card">
+                <div class="island stat-card has-spark">
                     <div class="island-header"><span class="stat-label">IPv4 站点 · CPU</span></div>
                     <div class="stat-value" id="ov-ipv4-cpu">--</div>
                     <div class="stat-sub" id="ov-ipv4-cpu-sub"></div>
+                    <div class="stat-spark" id="spark-ipv4-cpu"></div>
                 </div>
-                <div class="island stat-card">
+                <div class="island stat-card has-spark">
                     <div class="island-header"><span class="stat-label">IPv4 站点 · 内存</span></div>
                     <div class="stat-value" id="ov-ipv4-mem">--</div>
                     <div class="stat-sub" id="ov-ipv4-mem-sub"></div>
+                    <div class="stat-spark" id="spark-ipv4-mem"></div>
                 </div>
                 <div class="island stat-card">
                     <div class="island-header"><span class="stat-label">IPv6 站点 · 状态</span></div>
                     <div class="stat-value" id="ov-ipv6-status">--</div>
                 </div>
-                <div class="island stat-card">
+                <div class="island stat-card has-spark">
                     <div class="island-header"><span class="stat-label">IPv6 站点 · CPU</span></div>
                     <div class="stat-value" id="ov-ipv6-cpu">--</div>
                     <div class="stat-sub" id="ov-ipv6-cpu-sub"></div>
+                    <div class="stat-spark" id="spark-ipv6-cpu"></div>
                 </div>
-                <div class="island stat-card">
+                <div class="island stat-card has-spark">
                     <div class="island-header"><span class="stat-label">IPv6 站点 · 内存</span></div>
                     <div class="stat-value" id="ov-ipv6-mem">--</div>
                     <div class="stat-sub" id="ov-ipv6-mem-sub"></div>
+                    <div class="stat-spark" id="spark-ipv6-mem"></div>
                 </div>
             </div>
 

--- a/pages/status.js
+++ b/pages/status.js
@@ -312,6 +312,68 @@
         document.getElementById('ov-ipv6-mem-sub').textContent = (up6 === 1 && isFinite(mem6)) ? pctClass(mem6).replace('pct-', '') : '';
     }
 
+    /* ===== Overview sparklines (background area charts) ===== */
+    function hexToRgba(hex, alpha) {
+        var r = parseInt(hex.slice(1, 3), 16);
+        var g = parseInt(hex.slice(3, 5), 16);
+        var b = parseInt(hex.slice(5, 7), 16);
+        return 'rgba(' + r + ',' + g + ',' + b + ',' + alpha + ')';
+    }
+    function renderSpark(id, data, color) {
+        var c = getChart(id);
+        if (!c) return;
+        if (!data || !data.length) { c.clear(); delete chartOpts[id]; return; }
+        setChart(id, {
+            backgroundColor: 'transparent',
+            animation: true,
+            animationDuration: 800,
+            animationDurationUpdate: 800,
+            animationEasing: 'cubicOut',
+            grid: { left: 0, right: 0, top: 2, bottom: 0 },
+            xAxis: { type: 'time', show: false },
+            yAxis: { type: 'value', show: false, scale: true },
+            series: [{
+                type: 'line',
+                showSymbol: false,
+                smooth: true,
+                data: data,
+                lineStyle: { width: 1.5, color: color },
+                areaStyle: {
+                    color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+                        { offset: 0, color: hexToRgba(color, 0.35) },
+                        { offset: 1, color: hexToRgba(color, 0) }
+                    ])
+                }
+            }]
+        });
+    }
+    async function loadOverviewSparks() {
+        var iv = TIME_RANGES[state.range].interval;
+        var step = TIME_RANGES[state.range].step;
+        var end = Math.floor(Date.now() / 1000);
+        var start = end - TIME_RANGES[state.range].seconds;
+        var instBoth = IPV4 + '|' + IPV6;
+        var qCpu = '(1 - avg(irate(node_cpu_seconds_total{instance=~"' + instBoth + '",mode="idle"}[' + iv + '])) by (instance)) * 100';
+        var qMem = '(1 - (node_memory_MemAvailable_bytes{instance=~"' + instBoth + '"} / node_memory_MemTotal_bytes{instance=~"' + instBoth + '"})) * 100';
+        var results = await Promise.all([
+            promRange(qCpu, start, end, step).catch(function () { return []; }),
+            promRange(qMem, start, end, step).catch(function () { return []; })
+        ]);
+        function toMap(res) {
+            var m = {};
+            res.forEach(function (item) {
+                m[item.metric.instance] = item.values.map(function (v) { return [v[0] * 1000, parseFloat(v[1])]; });
+            });
+            return m;
+        }
+        var cpuMap = toMap(results[0]);
+        var memMap = toMap(results[1]);
+        renderSpark('spark-ipv4-cpu', cpuMap[IPV4], HOSTS[IPV4].color);
+        renderSpark('spark-ipv4-mem', memMap[IPV4], HOSTS[IPV4].color);
+        renderSpark('spark-ipv6-cpu', cpuMap[IPV6], HOSTS[IPV6].color);
+        renderSpark('spark-ipv6-mem', memMap[IPV6], HOSTS[IPV6].color);
+    }
+
     /* ===== Panel 2: Resource overview table ===== */
     async function loadResourceTable() {
         const inst = instanceSelector();
@@ -886,6 +948,7 @@
         }
         // Parallel load of all selector-dependent panels
         await Promise.all([
+            loadOverviewSparks().catch(function () {}),
             loadResourceTable().catch(function () {}),
             loadP99Table().catch(function () {}),
             loadPartitionTable().catch(function () {}),


### PR DESCRIPTION
## 功能

类似 Grafana Stat 面板启用 Graph 模式后的效果，在总览区 4 个 CPU/内存统计卡片底部叠加半透明面积图（sparkline），展示所选时间范围（1h/6h/24h）内的使用率变化趋势。

### 效果
- 卡片底部 42px 高度的面积图，颜色与站点一致（IPv4 酒红 / IPv6 蓝色）
- 面积渐变：顶部 35% 透明度 → 底部完全透明
- yAxis `scale: true` 自适应数据范围，让趋势变化清晰可见
- 无坐标轴、无 tooltip、无图例，纯背景装饰
- 文字内容通过 z-index 浮于面积图之上

### 涉及文件
- `pages/status.html` — 4 个 stat-card 添加 `has-spark` class 和 `<div class="stat-spark">` 容器
- `pages/status.css` — `.has-spark` / `.stat-spark` 样式
- `pages/status.js` — `hexToRgba()` / `renderSpark()` / `loadOverviewSparks()`，集成到 `refreshAll()`