### PR TITLE
添加容器镜像库(Harbor)监控选项卡

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -204,6 +204,37 @@
     font-weight: 400;
 }
 
+/* Tab navigation */
+.tab-nav {
+    display: flex;
+    gap: 4px;
+    max-width: 1200px;
+    margin: 0 auto var(--spacing-lg);
+    padding: 0 var(--spacing-md);
+    border-bottom: 1px solid var(--color-border);
+}
+.tab-link {
+    padding: 10px 24px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    border-bottom: 3px solid transparent;
+    transition: color var(--transition-fast), border-color var(--transition-fast);
+    margin-bottom: -1px;
+}
+.tab-link:hover { color: var(--color-text); }
+.tab-link.active {
+    color: var(--color-primary);
+    border-bottom-color: var(--color-primary);
+}
+.tab-panel { animation: tabFadeIn 0.3s ease-out; }
+.tab-panel[hidden] { display: none; }
+@keyframes tabFadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .stat-grid { grid-template-columns: repeat(2, 1fr); }

--- a/pages/status.html
+++ b/pages/status.html
@@ -60,8 +60,15 @@
     </div>
 </section>
 
+<!-- Tab navigation -->
+<nav class="tab-nav">
+    <a class="tab-link active" href="#mirrors" data-tab="mirrors">镜像站服务器</a>
+    <a class="tab-link" href="#harbor" data-tab="harbor">容器镜像库</a>
+</nav>
+
 <!-- Main -->
 <main class="main-container">
+  <div id="panel-mirrors" class="tab-panel">
     <div class="bento-grid">
         <div class="bento-main" style="grid-column: span 12;">
 
@@ -244,6 +251,94 @@
 
         </div>
     </div>
+  </div><!-- /panel-mirrors -->
+
+  <div id="panel-harbor" class="tab-panel" hidden>
+    <div class="bento-grid">
+        <div class="bento-main" style="grid-column: span 12;">
+
+            <div class="stat-grid" id="harbor-stat-grid">
+                <div class="island stat-card">
+                    <div class="island-header"><span class="stat-label">组件健康</span></div>
+                    <div class="stat-value" id="hb-health">--</div>
+                    <div class="stat-sub" id="hb-health-sub"></div>
+                </div>
+                <div class="island stat-card">
+                    <div class="island-header"><span class="stat-label">总项目数</span></div>
+                    <div class="stat-value" id="hb-projects">--</div>
+                    <div class="stat-sub" id="hb-projects-sub"></div>
+                </div>
+                <div class="island stat-card">
+                    <div class="island-header"><span class="stat-label">总仓库数</span></div>
+                    <div class="stat-value" id="hb-repos">--</div>
+                    <div class="stat-sub" id="hb-repos-sub"></div>
+                </div>
+                <div class="island stat-card">
+                    <div class="island-header"><span class="stat-label">总存储量</span></div>
+                    <div class="stat-value" id="hb-storage">--</div>
+                    <div class="stat-sub" id="hb-storage-sub"></div>
+                </div>
+            </div>
+
+            <div class="island" style="margin-bottom: var(--spacing-lg);">
+                <div class="island-header">
+                    <svg class="island-icon" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/>
+                    </svg>
+                    <h2 class="island-title">项目存储用量</h2>
+                </div>
+                <div class="data-table-wrap">
+                    <table class="data-table" id="harbor-project-table">
+                        <thead><tr>
+                            <th>项目</th><th>已用</th><th>配额</th><th>使用率</th><th>拉取次数</th>
+                        </tr></thead>
+                        <tbody id="harbor-project-tbody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="chart-grid">
+                <div class="island">
+                    <div class="island-header">
+                        <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M3 3v18h18"/><path d="M7 14l4-4 4 4 5-5"/>
+                        </svg>
+                        <h2 class="island-title">API 请求速率</h2>
+                    </div>
+                    <div class="chart-wrap" id="wrap-hb-api"><div class="chart-loading">加载中…</div><div class="chart" id="chart-hb-api"></div></div>
+                </div>
+                <div class="island">
+                    <div class="island-header">
+                        <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M3 12h4l3-9 4 18 3-9h4"/>
+                        </svg>
+                        <h2 class="island-title">并发请求</h2>
+                    </div>
+                    <div class="chart-wrap" id="wrap-hb-inflight"><div class="chart-loading">加载中…</div><div class="chart" id="chart-hb-inflight"></div></div>
+                </div>
+                <div class="island">
+                    <div class="island-header">
+                        <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/>
+                        </svg>
+                        <h2 class="island-title">任务队列大小</h2>
+                    </div>
+                    <div class="chart-wrap" id="wrap-hb-queue"><div class="chart-loading">加载中…</div><div class="chart" id="chart-hb-queue"></div></div>
+                </div>
+                <div class="island">
+                    <div class="island-header">
+                        <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+                        </svg>
+                        <h2 class="island-title">任务队列延迟</h2>
+                    </div>
+                    <div class="chart-wrap" id="wrap-hb-latency"><div class="chart-loading">加载中…</div><div class="chart" id="chart-hb-latency"></div></div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+  </div><!-- /panel-harbor -->
 </main>
 
 <!-- Footer -->

--- a/pages/status.js
+++ b/pages/status.js
@@ -3,6 +3,8 @@
 
     /* ===== Constants ===== */
     const PROM_URL = 'https://prometheus.gdutnic.com/api/v1';
+    const PROM_K8S_URL = 'https://prometheus-k8s.gdutnic.com/api/v1';
+    const HARBOR_JOB = 'job="harbor",namespace="gdut-mirrors"';
     const IPV4 = '202.116.132.67:9101';
     const IPV6 = '10.0.8.83:9101';
     const HOSTS = {
@@ -17,7 +19,7 @@
     const REFRESH_INTERVAL = 60;
 
     /* ===== State ===== */
-    const state = { range: '1h', site: 'both', promOK: true };
+    const state = { range: '1h', site: 'both', promOK: true, activeTab: 'mirrors' };
     const charts = {};   // id -> echarts instance
     const chartOpts = {}; // id -> last option (for re-theme)
     const chartFirstLoad = new Set(); // ids that haven't been rendered yet
@@ -113,6 +115,23 @@
         if (instance !== undefined) s = s.split('{INSTANCE}').join(instance);
         if (interval !== undefined) s = s.split('{INTERVAL}').join(interval);
         return s;
+    }
+    async function k8sInstant(query) {
+        const url = PROM_K8S_URL + '/query?query=' + encodeURIComponent(query);
+        const res = await fetch(url);
+        if (!res.ok) throw new Error('k8s Prometheus HTTP ' + res.status);
+        const json = await res.json();
+        if (json.status !== 'success') throw new Error('k8s Prometheus query failed: ' + (json.error || ''));
+        return json.data.result;
+    }
+    async function k8sRange(query, start, end, step) {
+        const url = PROM_K8S_URL + '/query_range?query=' + encodeURIComponent(query) +
+                    '&start=' + start + '&end=' + end + '&step=' + step;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error('k8s Prometheus HTTP ' + res.status);
+        const json = await res.json();
+        if (json.status !== 'success') throw new Error('k8s Prometheus query failed: ' + (json.error || ''));
+        return json.data.result;
     }
 
     /* ===== Instance selector from site choice ===== */
@@ -900,6 +919,286 @@
         } catch (e) { showChartEmpty('chart-agg-disk', '加载失败'); }
     }
 
+    /* ===== Harbor: Overview stat cards ===== */
+    async function loadHarborOverview() {
+        var sel = '{' + HARBOR_JOB + '}';
+        var queries = [
+            { key: 'up', q: 'harbor_up' + sel },
+            { key: 'projects', q: 'harbor_statistics_total_project_amount' + sel },
+            { key: 'repos', q: 'harbor_statistics_total_repo_amount' + sel },
+            { key: 'storage', q: 'harbor_statistics_total_storage_consumption' + sel },
+            { key: 'priv_proj', q: 'harbor_statistics_private_project_amount' + sel },
+            { key: 'pub_proj', q: 'harbor_statistics_public_project_amount' + sel },
+            { key: 'priv_repo', q: 'harbor_statistics_private_repo_amount' + sel },
+            { key: 'pub_repo', q: 'harbor_statistics_public_repo_amount' + sel }
+        ];
+        var results = await Promise.all(queries.map(function (q) { return k8sInstant(q.q).catch(function () { return []; }); }));
+        var map = {};
+        queries.forEach(function (q, i) { map[q.key] = results[i]; });
+
+        var upResults = map.up || [];
+        var upCount = upResults.filter(function (r) { return r.value[1] === '1'; }).length;
+        var totalComponents = upResults.length;
+        var elHealth = document.getElementById('hb-health');
+        if (totalComponents > 0) {
+            elHealth.textContent = upCount + '/' + totalComponents;
+            elHealth.className = 'stat-value ' + (upCount === totalComponents ? 'ok' : 'err');
+        } else { elHealth.textContent = '--'; elHealth.className = 'stat-value'; }
+        document.getElementById('hb-health-sub').textContent = totalComponents > 0 ? (upCount === totalComponents ? '全部在线' : (totalComponents - upCount) + ' 个离线') : '';
+
+        function val(arr) { return arr && arr[0] ? parseFloat(arr[0].value[1]) : NaN; }
+        var projects = val(map.projects);
+        document.getElementById('hb-projects').textContent = isFinite(projects) ? String(projects) : '--';
+        document.getElementById('hb-projects-sub').textContent = isFinite(projects) ? '私有 ' + (val(map.priv_proj) | 0) + ' · 公开 ' + (val(map.pub_proj) | 0) : '';
+
+        var repos = val(map.repos);
+        document.getElementById('hb-repos').textContent = isFinite(repos) ? String(repos) : '--';
+        document.getElementById('hb-repos-sub').textContent = isFinite(repos) ? '私有 ' + (val(map.priv_repo) | 0) + ' · 公开 ' + (val(map.pub_repo) | 0) : '';
+
+        var storage = val(map.storage);
+        document.getElementById('hb-storage').textContent = isFinite(storage) ? fmtBytes(storage) : '--';
+        document.getElementById('hb-storage-sub').textContent = '';
+    }
+
+    /* ===== Harbor: Project storage table ===== */
+    async function loadHarborProjectTable() {
+        tableSkeleton('harbor-project-tbody', 5);
+        var sel = '{' + HARBOR_JOB + '}';
+        var results = await Promise.all([
+            k8sInstant('harbor_project_quota_usage_byte' + sel).catch(function () { return []; }),
+            k8sInstant('harbor_project_quota_byte' + sel).catch(function () { return []; }),
+            k8sInstant('harbor_artifact_pulled' + sel).catch(function () { return []; })
+        ]);
+        var usageMap = {}, quotaMap = {}, pullMap = {};
+        results[0].forEach(function (r) { usageMap[r.metric.project_name] = parseFloat(r.value[1]); });
+        results[1].forEach(function (r) { quotaMap[r.metric.project_name] = parseFloat(r.value[1]); });
+        results[2].forEach(function (r) { pullMap[r.metric.project_name] = parseFloat(r.value[1]); });
+        var projects = Object.keys(usageMap);
+        if (!projects.length) { tableEmpty('harbor-project-tbody', '暂无数据', 5); return; }
+        projects.sort(function (a, b) { return (usageMap[b] || 0) - (usageMap[a] || 0); });
+        var html = '';
+        projects.forEach(function (name) {
+            var used = usageMap[name] || 0;
+            var quota = quotaMap[name] || 0;
+            var pulls = pullMap[name] || 0;
+            var pct = quota > 0 ? (used / quota * 100) : 0;
+            var uClamped = Math.max(0, Math.min(100, pct));
+            var barColor = usageGradientColor(uClamped);
+            html += '<tr class="partition-row" data-bar-w="' + uClamped.toFixed(1) + '" data-bar-c="' + barColor + '">'
+                + '<td class="col-site">' + name + '</td>'
+                + '<td>' + fmtBytes(used) + '</td>'
+                + '<td>' + (quota > 0 ? fmtBytes(quota) : '-') + '</td>'
+                + '<td class="pct-tag ' + pctClass(pct) + '">' + (quota > 0 ? fmtPct(pct) : '-') + '</td>'
+                + '<td>' + (pulls > 0 ? String(pulls) : '-') + '</td>'
+                + '</tr>';
+        });
+        document.getElementById('harbor-project-tbody').innerHTML = html;
+        var barRows = document.querySelectorAll('#harbor-project-tbody .partition-row');
+        barRows.forEach(function (tr) {
+            var color = tr.dataset.barC || 'transparent';
+            tr.style.background = 'linear-gradient(90deg, ' + color + ' 0%, transparent 0%)';
+        });
+        var island = document.getElementById('harbor-project-tbody').closest('.island');
+        function runBarAnimation() {
+            barRows.forEach(function (tr, idx) {
+                var targetW = parseFloat(tr.dataset.barW) || 0;
+                var color = tr.dataset.barC || 'transparent';
+                setTimeout(function () {
+                    var startTime = null;
+                    function step(ts) {
+                        if (!startTime) startTime = ts;
+                        var progress = Math.min((ts - startTime) / 1200, 1);
+                        var eased = 1 - Math.pow(1 - progress, 3);
+                        var curW = targetW * eased;
+                        tr.style.background = 'linear-gradient(90deg, ' + color + ' ' + curW.toFixed(1) + '%, transparent ' + curW.toFixed(1) + '%)';
+                        if (progress < 1) requestAnimationFrame(step);
+                    }
+                    requestAnimationFrame(step);
+                }, idx * 80);
+            });
+        }
+        if (island) {
+            var visObs = new IntersectionObserver(function (entries) {
+                if (entries[0].isIntersecting) {
+                    visObs.disconnect();
+                    setTimeout(runBarAnimation, 700);
+                }
+            }, { threshold: 0.15 });
+            visObs.observe(island);
+        }
+    }
+
+    /* ===== Harbor: API request rate chart ===== */
+    async function loadHarborApiChart() {
+        showChartLoading('chart-hb-api');
+        var sel = '{' + HARBOR_JOB + '}';
+        var iv = TIME_RANGES[state.range].interval;
+        var step = TIME_RANGES[state.range].step;
+        var end = Math.floor(Date.now() / 1000);
+        var start = end - TIME_RANGES[state.range].seconds;
+        var q = 'sum by (method) (rate(harbor_core_http_request_total' + sel + '[' + iv + ']))';
+        try {
+            var result = await k8sRange(q, start, end, step);
+            if (!result.length) { showChartEmpty('chart-hb-api', '暂无数据'); return; }
+            var palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'];
+            var series = result.map(function (item, i) {
+                var method = item.metric.method || 'unknown';
+                return {
+                    name: method,
+                    type: 'line',
+                    showSymbol: false,
+                    smooth: true,
+                    lineStyle: { width: 2 },
+                    itemStyle: { color: palette[i % palette.length] },
+                    data: item.values.map(function (v) { return [v[0] * 1000, parseFloat(v[1])]; })
+                };
+            });
+            renderChart('chart-hb-api', {
+                backgroundColor: 'transparent',
+                tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return v.toFixed(2) + ' req/s'; } }),
+                legend: { top: 0, textStyle: { color: themeColors().text } },
+                grid: { left: 60, right: 20, top: 36, bottom: 30 },
+                xAxis: timeXAxis(),
+                yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}' } }),
+                series: series
+            });
+        } catch (e) { showChartEmpty('chart-hb-api', '加载失败'); }
+    }
+
+    /* ===== Harbor: Inflight requests chart ===== */
+    async function loadHarborInflightChart() {
+        showChartLoading('chart-hb-inflight');
+        var sel = '{' + HARBOR_JOB + '}';
+        var step = TIME_RANGES[state.range].step;
+        var end = Math.floor(Date.now() / 1000);
+        var start = end - TIME_RANGES[state.range].seconds;
+        var q = 'harbor_core_http_inflight_requests' + sel;
+        try {
+            var result = await k8sRange(q, start, end, step);
+            if (!result.length) { showChartEmpty('chart-hb-inflight', '暂无数据'); return; }
+            var series = result.map(function (item) {
+                return {
+                    name: item.metric.instance || 'harbor',
+                    type: 'line',
+                    showSymbol: false,
+                    smooth: true,
+                    lineStyle: { width: 2 },
+                    itemStyle: { color: '#3b82f6' },
+                    areaStyle: { color: hexToRgba('#3b82f6', 0.15) },
+                    data: item.values.map(function (v) { return [v[0] * 1000, parseFloat(v[1])]; })
+                };
+            });
+            renderChart('chart-hb-inflight', {
+                backgroundColor: 'transparent',
+                tooltip: baseTooltip(),
+                legend: { top: 0, textStyle: { color: themeColors().text } },
+                grid: { left: 50, right: 20, top: 36, bottom: 30 },
+                xAxis: timeXAxis(),
+                yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text } }),
+                series: series
+            });
+        } catch (e) { showChartEmpty('chart-hb-inflight', '加载失败'); }
+    }
+
+    /* ===== Harbor: Task queue size chart ===== */
+    async function loadHarborQueueChart() {
+        showChartLoading('chart-hb-queue');
+        var sel = '{' + HARBOR_JOB + '}';
+        var step = TIME_RANGES[state.range].step;
+        var end = Math.floor(Date.now() / 1000);
+        var start = end - TIME_RANGES[state.range].seconds;
+        var q = 'sum by (type) (harbor_task_queue_size' + sel + ')';
+        try {
+            var result = await k8sRange(q, start, end, step);
+            if (!result.length) { showChartEmpty('chart-hb-queue', '暂无数据'); return; }
+            var palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#14b8a6'];
+            var series = result.map(function (item, i) {
+                var qtype = item.metric.type || 'unknown';
+                return {
+                    name: qtype,
+                    type: 'line',
+                    showSymbol: false,
+                    smooth: true,
+                    stack: 'total',
+                    lineStyle: { width: 1.5 },
+                    itemStyle: { color: palette[i % palette.length] },
+                    areaStyle: { opacity: 0.3 },
+                    data: item.values.map(function (v) { return [v[0] * 1000, parseFloat(v[1])]; })
+                };
+            });
+            renderChart('chart-hb-queue', {
+                backgroundColor: 'transparent',
+                tooltip: baseTooltip(),
+                legend: { top: 0, textStyle: { color: themeColors().text }, type: 'scroll' },
+                grid: { left: 50, right: 20, top: 36, bottom: 30 },
+                xAxis: timeXAxis(),
+                yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text } }),
+                series: series
+            });
+        } catch (e) { showChartEmpty('chart-hb-queue', '加载失败'); }
+    }
+
+    /* ===== Harbor: Task queue latency chart ===== */
+    async function loadHarborLatencyChart() {
+        showChartLoading('chart-hb-latency');
+        var sel = '{' + HARBOR_JOB + '}';
+        var step = TIME_RANGES[state.range].step;
+        var end = Math.floor(Date.now() / 1000);
+        var start = end - TIME_RANGES[state.range].seconds;
+        var q = 'harbor_task_queue_latency' + sel;
+        try {
+            var result = await k8sRange(q, start, end, step);
+            if (!result.length) { showChartEmpty('chart-hb-latency', '暂无数据'); return; }
+            var palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#14b8a6'];
+            var series = result.map(function (item, i) {
+                var qtype = item.metric.type || 'unknown';
+                return {
+                    name: qtype,
+                    type: 'line',
+                    showSymbol: false,
+                    smooth: true,
+                    lineStyle: { width: 2 },
+                    itemStyle: { color: palette[i % palette.length] },
+                    data: item.values.map(function (v) { return [v[0] * 1000, parseFloat(v[1])]; })
+                };
+            });
+            renderChart('chart-hb-latency', {
+                backgroundColor: 'transparent',
+                tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return v.toFixed(2) + ' s'; } }),
+                legend: { top: 0, textStyle: { color: themeColors().text }, type: 'scroll' },
+                grid: { left: 60, right: 20, top: 36, bottom: 30 },
+                xAxis: timeXAxis(),
+                yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}s' } }),
+                series: series
+            });
+        } catch (e) { showChartEmpty('chart-hb-latency', '加载失败'); }
+    }
+
+    /* ===== Harbor: Refresh orchestration ===== */
+    async function refreshHarbor() {
+        var banner = document.getElementById('error-banner');
+        try {
+            await loadHarborOverview();
+            banner.hidden = true;
+        } catch (e) {
+            banner.hidden = false;
+            return;
+        }
+        await Promise.all([
+            loadHarborProjectTable().catch(function () {}),
+            loadHarborApiChart().catch(function () {}),
+            loadHarborInflightChart().catch(function () {}),
+            loadHarborQueueChart().catch(function () {}),
+            loadHarborLatencyChart().catch(function () {})
+        ]);
+        var now = new Date();
+        document.getElementById('last-refresh').textContent = '上次刷新: ' +
+            String(now.getHours()).padStart(2, '0') + ':' +
+            String(now.getMinutes()).padStart(2, '0') + ':' +
+            String(now.getSeconds()).padStart(2, '0');
+        countdown = REFRESH_INTERVAL;
+    }
+
     /* ===== Theme re-apply for all charts ===== */
     function rethemeCharts() {
         Object.keys(chartOpts).forEach(function (id) {
@@ -976,7 +1275,10 @@
         refreshTimer = setInterval(function () {
             countdown--;
             document.getElementById('next-refresh').textContent = '下次刷新: ' + countdown + 's';
-            if (countdown <= 0) { refreshAll(); }
+            if (countdown <= 0) {
+                if (state.activeTab === 'harbor') { refreshHarbor(); }
+                else { refreshAll(); }
+            }
         }, 1000);
     }
 
@@ -988,11 +1290,14 @@
             document.querySelectorAll('.time-btn').forEach(function (b) { b.classList.remove('active'); });
             btn.classList.add('active');
             state.range = btn.dataset.range;
-            refreshAll();
+            if (state.activeTab === 'harbor') {
+                refreshHarbor();
+            } else {
+                refreshAll();
+            }
         });
         document.getElementById('site-selector').addEventListener('change', function (e) {
             state.site = e.target.value;
-            // Reload selector-dependent panels only (not overview)
             Promise.all([
                 loadResourceTable().catch(function () {}),
                 loadP99Table().catch(function () {}),
@@ -1008,6 +1313,43 @@
                 loadAggDisk().catch(function () {})
             ]);
         });
+    }
+
+    /* ===== Tab routing ===== */
+    function switchTab(tab) {
+        if (tab !== 'mirrors' && tab !== 'harbor') tab = 'mirrors';
+        state.activeTab = tab;
+        document.querySelectorAll('.tab-link').forEach(function (link) {
+            link.classList.toggle('active', link.dataset.tab === tab);
+        });
+        var panelMirrors = document.getElementById('panel-mirrors');
+        var panelHarbor = document.getElementById('panel-harbor');
+        var siteSel = document.getElementById('site-selector');
+        if (tab === 'harbor') {
+            panelMirrors.hidden = true;
+            panelHarbor.hidden = false;
+            siteSel.style.display = 'none';
+        } else {
+            panelMirrors.hidden = false;
+            panelHarbor.hidden = true;
+            siteSel.style.display = '';
+        }
+        if (refreshTimer) clearInterval(refreshTimer);
+        document.getElementById('next-refresh').textContent = '下次刷新: ' + REFRESH_INTERVAL + 's';
+        var panel = tab === 'harbor' ? panelHarbor : panelMirrors;
+        var panelCharts = panel.querySelectorAll('.chart');
+        setTimeout(function () {
+            panelCharts.forEach(function (el) {
+                var inst = echarts.getInstanceByDom(el);
+                if (inst) inst.resize();
+            });
+        }, 50);
+        if (tab === 'harbor') {
+            refreshHarbor();
+        } else {
+            refreshAll();
+        }
+        startRefreshTimer();
     }
 
     /* ===== Resize handling ===== */
@@ -1030,11 +1372,24 @@
     /* ===== Init ===== */
     function init() {
         document.getElementById('copyright-year').textContent = new Date().getFullYear();
-        var chartIds = ['chart-cpu','chart-mem','chart-disk','chart-load','chart-net','chart-bargauge','chart-agg-load','chart-agg-mem','chart-agg-disk'];
+        var chartIds = ['chart-cpu','chart-mem','chart-disk','chart-load','chart-net','chart-bargauge','chart-agg-load','chart-agg-mem','chart-agg-disk',
+                        'chart-hb-api','chart-hb-inflight','chart-hb-queue','chart-hb-latency'];
         chartIds.forEach(function (id) { chartFirstLoad.add(id); });
         bindControls();
-        refreshAll();
-        startRefreshTimer();
+        window.addEventListener('hashchange', function () {
+            var hash = (window.location.hash || '#mirrors').slice(1);
+            switchTab(hash);
+        });
+        var initialTab = (window.location.hash || '#mirrors').slice(1);
+        if (initialTab === 'harbor') {
+            switchTab('harbor');
+        } else {
+            if (window.location.hash && initialTab !== 'mirrors') {
+                window.location.hash = '#mirrors';
+            }
+            refreshAll();
+            startRefreshTimer();
+        }
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## 功能

在状态页面新增 URL hash 路由选项卡：`#mirrors`（镜像站服务器）和 `#harbor`（容器镜像库）。

### Harbor 监控内容

数据源：`https://prometheus-k8s.gdutnic.com`（已搭好的 Nginx 反代 k8s Prometheus）

**4 个 stat 卡片**：
- 组件健康：8 个组件（core/database/jobservice/portal/redis/registry/registryctl/trivy）在线数
- 总项目数：私有/公开分布
- 总仓库数：私有/公开分布
- 总存储量

**项目存储用量表**：
- 项目名 / 已用 / 配额 / 使用率进度条 / 拉取次数
- 按用量降序，35+ 个项目

**4 个时间序列图表**：
- API 请求速率：`rate(harbor_core_http_request_total[5m])` by method
- 并发请求：`harbor_core_http_inflight_requests`
- 任务队列大小：`sum(harbor_task_queue_size)` by type（堆叠面积图）
- 任务队列延迟：`harbor_task_queue_latency` by type

### 选项卡机制
- URL hash 路由：`status.html#harbor` 可直接分享
- 切换 tab 时停止旧刷新循环，立即加载新 tab，接管 60s 定时器
- 站点选择器只在镜像站 tab 显示
- 主题切换时 `rethemeCharts()` 遍历所有图表，切换 tab 时 `resize()` 刚显示的图表

### 涉及文件
- `pages/status.html` — tab 导航 + panel-mirrors/panel-harbor 结构
- `pages/status.css` — tab 导航栏样式 + panel 显隐过渡动画
- `pages/status.js` — k8s Prometheus 查询 + 6 个 Harbor load 函数 + hashchange 路由