### PR TITLE
修复 Harbor API 请求速率图 rate 窗口过短

### DIFF
--- a/pages/status.js
+++ b/pages/status.js
@@ -1032,11 +1032,10 @@
     async function loadHarborApiChart() {
         showChartLoading('chart-hb-api');
         var sel = '{' + HARBOR_JOB + '}';
-        var iv = TIME_RANGES[state.range].interval;
         var step = TIME_RANGES[state.range].step;
         var end = Math.floor(Date.now() / 1000);
         var start = end - TIME_RANGES[state.range].seconds;
-        var q = 'sum by (method) (rate(harbor_core_http_request_total' + sel + '[' + iv + ']))';
+        var q = 'sum by (method) (rate(harbor_core_http_request_total' + sel + '[5m]))';
         try {
             var result = await k8sRange(q, start, end, step);
             if (!result.length) { showChartEmpty('chart-hb-api', '暂无数据'); return; }


### PR DESCRIPTION
## 修复

`rate(harbor_core_http_request_total[1m])` 窗口太短——Harbor exporter 的 scrape interval 为 1m，1m 窗口内只有 1-2 个数据点，`rate()` 无法计算返回空结果。

改为固定 `[5m]` 窗口，确保有足够数据点计算 rate。

### 涉及文件
- `pages/status.js` — `loadHarborApiChart()` 中 `iv` 变量替换为固定 `5m`