### PR TITLE
修复选项卡点击无响应 + 改为 Island pill 风格

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -205,28 +205,35 @@
 }
 
 /* Tab navigation */
-.tab-nav {
+.tab-nav-wrap {
     display: flex;
+    justify-content: center;
+    margin-bottom: var(--spacing-lg);
+}
+.tab-nav {
+    display: inline-flex;
     gap: 4px;
-    max-width: 1200px;
-    margin: 0 auto var(--spacing-lg);
-    padding: 0 var(--spacing-md);
-    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
+    padding: 4px;
+    box-shadow: var(--shadow-sm);
 }
 .tab-link {
-    padding: 10px 24px;
-    font-size: 0.9375rem;
+    padding: 8px 28px;
+    font-size: 0.875rem;
     font-weight: 600;
-    color: var(--color-text-muted);
+    color: var(--color-text-secondary);
     text-decoration: none;
-    border-bottom: 3px solid transparent;
-    transition: color var(--transition-fast), border-color var(--transition-fast);
-    margin-bottom: -1px;
+    border-radius: var(--radius-lg);
+    transition: all var(--transition-fast);
+    cursor: pointer;
 }
 .tab-link:hover { color: var(--color-text); }
 .tab-link.active {
-    color: var(--color-primary);
-    border-bottom-color: var(--color-primary);
+    background: var(--gradient-primary);
+    color: #fff;
+    box-shadow: var(--shadow-sm);
 }
 .tab-panel { animation: tabFadeIn 0.3s ease-out; }
 .tab-panel[hidden] { display: none; }

--- a/pages/status.html
+++ b/pages/status.html
@@ -61,10 +61,12 @@
 </section>
 
 <!-- Tab navigation -->
-<nav class="tab-nav">
-    <a class="tab-link active" href="#mirrors" data-tab="mirrors">镜像站服务器</a>
-    <a class="tab-link" href="#harbor" data-tab="harbor">容器镜像库</a>
-</nav>
+<div class="tab-nav-wrap">
+    <nav class="tab-nav">
+        <a class="tab-link active" href="#mirrors" data-tab="mirrors">镜像站服务器</a>
+        <a class="tab-link" href="#harbor" data-tab="harbor">容器镜像库</a>
+    </nav>
+</div>
 
 <!-- Main -->
 <main class="main-container">

--- a/pages/status.js
+++ b/pages/status.js
@@ -1295,6 +1295,17 @@
                 refreshAll();
             }
         });
+        document.querySelectorAll('.tab-link').forEach(function (link) {
+            link.addEventListener('click', function (e) {
+                e.preventDefault();
+                var tab = link.dataset.tab;
+                if (tab === state.activeTab) return;
+                if (window.location.hash !== '#' + tab) {
+                    history.pushState(null, '', '#' + tab);
+                }
+                switchTab(tab);
+            });
+        });
         document.getElementById('site-selector').addEventListener('change', function (e) {
             state.site = e.target.value;
             Promise.all([


### PR DESCRIPTION
## 修复

### 1. 点击无响应
`<a href="#harbor">` 的默认导航行为在某些浏览器中不触发 `hashchange` 事件。

改为 JS `click` 事件拦截：`preventDefault` + 手动 `switchTab()`，同时用 `history.pushState` 更新 URL hash，保留分享和前进后退能力。

### 2. 样式改为 Island pill 风格
从底部边框线样式改为与 `time-selector` 一致的 pill/capsule 容器：
- 圆角容器 (`radius-xl`) + `surface` 背景 + `shadow-sm`
- 活跃 tab 用 `gradient-primary` 渐变 + 白色文字
- 居中显示

### 涉及文件
- `pages/status.html` — tab-nav 外加居中包裹容器
- `pages/status.css` — pill 风格 tab 样式
- `pages/status.js` — `bindControls` 中添加 tab click 拦截