### PR TITLE
时间选择器和选项卡添加滑动指示器动画

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -26,6 +26,7 @@
     box-shadow: var(--shadow-sm);
     height: 39px;
     box-sizing: border-box;
+    position: relative;
 }
 .time-btn {
     border: none;
@@ -36,15 +37,13 @@
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
-    transition: all var(--transition-fast);
+    transition: color var(--transition-fast);
     font-family: inherit;
+    position: relative;
+    z-index: 1;
 }
 .time-btn:hover { color: var(--color-text); }
-.time-btn.active {
-    background: var(--gradient-primary);
-    color: #fff;
-    box-shadow: var(--shadow-sm);
-}
+.time-btn.active { color: #fff; }
 .site-selector {
     padding: 0 36px 0 16px;
     border: 1px solid var(--color-border);
@@ -214,6 +213,7 @@
     padding: 4px;
     box-shadow: var(--shadow-sm);
     margin-top: var(--spacing-lg);
+    position: relative;
 }
 .tab-link {
     padding: 8px 28px;
@@ -222,14 +222,26 @@
     color: var(--color-text-secondary);
     text-decoration: none;
     border-radius: var(--radius-lg);
-    transition: all var(--transition-fast);
+    transition: color var(--transition-fast);
     cursor: pointer;
+    position: relative;
+    z-index: 1;
 }
 .tab-link:hover { color: var(--color-text); }
-.tab-link.active {
+.tab-link.active { color: #fff; }
+
+/* Slide indicator (shared by time-selector and tab-nav) */
+.slide-indicator {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    height: calc(100% - 8px);
+    border-radius: var(--radius-lg);
     background: var(--gradient-primary);
-    color: #fff;
     box-shadow: var(--shadow-sm);
+    z-index: 0;
+    transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), width 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
 }
 .tab-panel { animation: tabFadeIn 0.3s ease-out; }
 .tab-panel[hidden] { display: none; }

--- a/pages/status.html
+++ b/pages/status.html
@@ -42,6 +42,7 @@
         <p class="hero-subtitle">广东工业大学开源镜像站服务器实时监控</p>
         <div class="hero-controls">
             <div class="time-selector" id="time-selector">
+                <div class="slide-indicator"></div>
                 <button class="time-btn active" data-range="1h">1h</button>
                 <button class="time-btn" data-range="6h">6h</button>
                 <button class="time-btn" data-range="24h">24h</button>
@@ -58,6 +59,7 @@
             </div>
         </div>
         <nav class="tab-nav" id="tab-nav">
+            <div class="slide-indicator"></div>
             <a class="tab-link active" href="#mirrors" data-tab="mirrors">镜像站服务器</a>
             <a class="tab-link" href="#harbor" data-tab="harbor">容器镜像库</a>
         </nav>

--- a/pages/status.js
+++ b/pages/status.js
@@ -1281,6 +1281,16 @@
         }, 1000);
     }
 
+    /* ===== Slide indicator ===== */
+    function moveIndicator(container) {
+        if (!container) return;
+        var active = container.querySelector('.active');
+        var indicator = container.querySelector('.slide-indicator');
+        if (!active || !indicator) return;
+        indicator.style.transform = 'translateX(' + active.offsetLeft + 'px)';
+        indicator.style.width = active.offsetWidth + 'px';
+    }
+
     /* ===== Selector handlers ===== */
     function bindControls() {
         document.getElementById('time-selector').addEventListener('click', function (e) {
@@ -1288,6 +1298,7 @@
             if (!btn) return;
             document.querySelectorAll('.time-btn').forEach(function (b) { b.classList.remove('active'); });
             btn.classList.add('active');
+            moveIndicator(document.getElementById('time-selector'));
             state.range = btn.dataset.range;
             if (state.activeTab === 'harbor') {
                 refreshHarbor();
@@ -1332,6 +1343,7 @@
         document.querySelectorAll('.tab-link').forEach(function (link) {
             link.classList.toggle('active', link.dataset.tab === tab);
         });
+        moveIndicator(document.getElementById('tab-nav'));
         var panelMirrors = document.getElementById('panel-mirrors');
         var panelHarbor = document.getElementById('panel-harbor');
         var siteSel = document.getElementById('site-selector');
@@ -1368,6 +1380,8 @@
         clearTimeout(resizeTO);
         resizeTO = setTimeout(function () {
             Object.keys(charts).forEach(function (id) { if (charts[id]) charts[id].resize(); });
+            moveIndicator(document.getElementById('time-selector'));
+            moveIndicator(document.getElementById('tab-nav'));
         }, 200);
     });
 
@@ -1386,6 +1400,8 @@
                         'chart-hb-api','chart-hb-inflight','chart-hb-queue','chart-hb-latency'];
         chartIds.forEach(function (id) { chartFirstLoad.add(id); });
         bindControls();
+        moveIndicator(document.getElementById('time-selector'));
+        moveIndicator(document.getElementById('tab-nav'));
         window.addEventListener('hashchange', function () {
             var hash = (window.location.hash || '#mirrors').slice(1);
             switchTab(hash);


### PR DESCRIPTION
## 功能

在 time-selector（1h/6h/24h）和 tab-nav（镜像站服务器/容器镜像库）中各添加滑动指示器，切换时指示器从当前位置平滑滑动到目标位置。

### 实现
- 每个容器内添加 `<div class="slide-indicator">` 绝对定位元素
- JS `moveIndicator()` 根据当前 active 项的 `offsetLeft`/`offsetWidth` 设置 `transform: translateX()` 和 `width`
- CSS `transition: 0.35s cubic-bezier(0.4, 0, 0.2, 1)` 实现平滑滑动
- active 项自身不再设背景色，由 indicator 统一提供 `gradient-primary` 渐变
- resize 时重新计算位置

### 涉及文件
- `pages/status.html` — 两个容器各添加 `slide-indicator` div
- `pages/status.css` — indicator 样式 + 容器 `position: relative` + 按钮 `z-index: 1`
- `pages/status.js` — `moveIndicator()` 函数 + init/resize/切换时调用