### PR TITLE
修复滑动指示器偏右 4px

### DIFF
--- a/pages/status.css
+++ b/pages/status.css
@@ -234,7 +234,7 @@
 .slide-indicator {
     position: absolute;
     top: 4px;
-    left: 4px;
+    left: 0;
     height: calc(100% - 8px);
     border-radius: var(--radius-lg);
     background: var(--gradient-primary);


### PR DESCRIPTION
indicator 的 `left: 4px` 与 JS 的 `translateX(offsetLeft)` 双重叠加——`offsetLeft` 已包含容器 `padding: 4px`，两者叠加导致整体右移 4px。改为 `left: 0` 消除双倍偏移。