### PR TITLE
新增镜像统计表：聚合磁盘占用/请求次数/同步状态展示在状态页

### DIFF
--- a/crontab
+++ b/crontab
@@ -27,5 +27,7 @@
 59 23 * * * /bin/python3 /home/mirror/mirror_daily_summary.py > /mnt/mirror/daily_stat.txt
 # 每周日23:30发送磁盘数据
 30 23 * * 0  /bin/python3 /home/mirror/mirror_disk_summary.py
+# 每小时整点生成镜像统计数据JSON（供status.html前端消费）
+0 * * * * /bin/python3 /home/mirror/mirrors-gdut/mirror_stats_json.py
 # 缓存预热
 # 0 4 * * *  cd /home/mirror/tmp; python3 /home/mirror/mirrors-gdut/mirror_auto_cache.py > /tmp/mirror_auto_cache.log

--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""聚合镜像站统计数据，输出 JSON 供 status.html 前端消费。"""
+
+import csv
+import glob
+import json
+import os
+import subprocess
+from datetime import datetime
+
+MIRROR_DIR = '/mnt/mirror'
+CACHE_DIR = '/home/mirror/nginx_cache'
+SYNC_TIME_DIR = '/home/mirror/sync_time'
+LOCK_DIR = '/tmp/mirror/lock'
+LOG_DIR = '/home/mirror/log'
+OUTPUT_FILE = '/mnt/mirror/mirror_stats.json'
+
+CDN_MIRROR_LIST = {
+    'pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis',
+    'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports',
+    'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora',
+    'rubygems'
+}
+
+PROXY_MIRRORS = {'docker', 'maven', 'npm', 'go', 'crates.io-index'}
+
+IGNORE_DIR = {
+    'static', 'font', 'help', 'Nginx-Fancyindex-Theme',
+    'certs', 'git', 'scripts', 'ubuntu-cloud-images'
+}
+
+CACHE_DIR_MAP = {
+    'homebrew-bottles': 'homebrew_bottles',
+}
+
+
+def get_disk_usage_gb(path):
+    try:
+        result = subprocess.run(
+            ['du', '-sb', path],
+            capture_output=True, text=True, timeout=300
+        )
+        if result.returncode == 0:
+            bytes_size = int(result.stdout.split()[0])
+            return round(bytes_size / (1024 ** 3), 1)
+    except (subprocess.TimeoutExpired, ValueError, IndexError):
+        pass
+    return None
+
+
+def read_csv_stats():
+    total = {}
+    daily = {}
+
+    try:
+        with open(os.path.join(LOG_DIR, 'total.csv'), 'r') as f:
+            reader = csv.reader(f)
+            next(reader, None)
+            for row in reader:
+                if len(row) == 2:
+                    try:
+                        total[row[0]] = int(row[1])
+                    except ValueError:
+                        pass
+    except (FileNotFoundError, StopIteration):
+        pass
+
+    daily_csv = os.path.join(LOG_DIR, 'daily_%s.csv' % datetime.now().strftime('%Y%m%d'))
+    try:
+        with open(daily_csv, 'r') as f:
+            reader = csv.reader(f)
+            next(reader, None)
+            for row in reader:
+                if len(row) == 2:
+                    try:
+                        daily[row[0]] = int(row[1])
+                    except ValueError:
+                        pass
+    except (FileNotFoundError, StopIteration):
+        pass
+
+    return total, daily
+
+
+def get_sync_info(mirror_name, is_cache):
+    if is_cache:
+        return None, 'cache'
+
+    sync_time_file = os.path.join(SYNC_TIME_DIR, mirror_name)
+    lock_file = os.path.join(LOCK_DIR, mirror_name + '.lock')
+
+    try:
+        with open(sync_time_file, 'r') as f:
+            sync_time = f.read().strip()
+    except FileNotFoundError:
+        return None, 'never'
+
+    if os.path.isfile(lock_file):
+        return sync_time, 'syncing'
+
+    return sync_time, 'completed'
+
+
+def main():
+    total_stats, daily_stats = read_csv_stats()
+
+    mirrors = []
+    for mirror_path in sorted(glob.glob(os.path.join(MIRROR_DIR, '*'))):
+        if not os.path.isdir(mirror_path):
+            continue
+
+        mirror_name = os.path.basename(mirror_path)
+        if mirror_name in IGNORE_DIR:
+            continue
+
+        is_cache = mirror_name in CDN_MIRROR_LIST
+        is_proxy = mirror_name in PROXY_MIRRORS
+
+        if is_proxy:
+            disk_usage = None
+        elif is_cache:
+            cache_name = CACHE_DIR_MAP.get(mirror_name, mirror_name)
+            disk_usage = get_disk_usage_gb(os.path.join(CACHE_DIR, cache_name))
+        else:
+            disk_usage = get_disk_usage_gb(mirror_path)
+
+        sync_time, sync_status = get_sync_info(mirror_name, is_cache)
+
+        if is_proxy:
+            mirror_type = 'proxy'
+        elif is_cache:
+            mirror_type = 'cache'
+        else:
+            mirror_type = 'full'
+
+        mirrors.append({
+            'name': mirror_name,
+            'disk_usage_gb': disk_usage,
+            'total_requests': total_stats.get(mirror_name, 0),
+            'daily_requests': daily_stats.get(mirror_name, 0),
+            'type': mirror_type,
+            'sync_time': sync_time,
+            'sync_status': sync_status,
+        })
+
+    output = {
+        'generated_at': datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
+        'mirrors': mirrors,
+    }
+
+    with open(OUTPUT_FILE, 'w') as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+
+    print('统计完成：%d 个镜像，输出到 %s' % (len(mirrors), OUTPUT_FILE))
+
+
+if __name__ == '__main__':
+    main()

--- a/pages/status.css
+++ b/pages/status.css
@@ -168,6 +168,53 @@
 .pct-crit { color: var(--color-error); }
 .partition-row > td { background-color: transparent; }
 
+/* Mirror stats sortable table */
+.mirror-stats-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+    transition: color var(--transition-fast);
+}
+.mirror-stats-table th.sortable:hover { color: var(--color-primary); }
+.mirror-stats-table th.sortable::after {
+    content: '↕';
+    margin-left: 6px;
+    opacity: 0.3;
+    font-size: 0.75rem;
+}
+.mirror-stats-table th.sortable.sorted-asc::after { content: '↑'; opacity: 1; }
+.mirror-stats-table th.sortable.sorted-desc::after { content: '↓'; opacity: 1; }
+.type-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: var(--radius-full, 999px);
+    font-size: 0.75rem;
+    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+}
+.type-badge.full { background: rgba(16, 185, 129, 0.15); color: var(--color-success); }
+.type-badge.cache { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
+.type-badge.proxy { background: rgba(245, 158, 11, 0.15); color: var(--color-warning); }
+.mirror-name { font-family: 'Inter', sans-serif; font-weight: 600; color: var(--color-text); }
+.disk-bar {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.disk-bar-track {
+    width: 60px;
+    height: 6px;
+    background: var(--color-border);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.disk-bar-fill {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+    background: var(--gradient-primary);
+    transition: width var(--transition-base);
+}
+
 /* Charts */
 .chart-grid {
     display: grid;

--- a/pages/status.html
+++ b/pages/status.html
@@ -249,6 +249,32 @@
                 </div>
             </div>
 
+            <!-- Mirror stats table -->
+            <div class="island" style="margin-top: var(--spacing-lg);">
+                <div class="island-header">
+                    <svg class="island-icon" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/>
+                        <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
+                        <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
+                    </svg>
+                    <h2 class="island-title">镜像统计<span class="island-note" id="mirror-stats-time">--</span></h2>
+                </div>
+                <div class="data-table-wrap">
+                    <table class="data-table mirror-stats-table" id="mirror-stats-table">
+                        <thead><tr>
+                            <th class="sortable" data-sort="name">镜像名称</th>
+                            <th class="sortable" data-sort="type">类型</th>
+                            <th class="sortable" data-sort="sync_status">同步状态</th>
+                            <th class="sortable" data-sort="sync_time">最近同步</th>
+                            <th class="sortable" data-sort="disk_usage_gb">磁盘占用</th>
+                            <th class="sortable" data-sort="total_requests">累计请求</th>
+                            <th class="sortable" data-sort="daily_requests">当日请求</th>
+                        </tr></thead>
+                        <tbody id="mirror-stats-tbody"></tbody>
+                    </table>
+                </div>
+            </div>
+
         </div>
     </div>
   </div><!-- /panel-mirrors -->

--- a/pages/status.js
+++ b/pages/status.js
@@ -919,6 +919,90 @@
         } catch (e) { showChartEmpty('chart-agg-disk', '加载失败'); }
     }
 
+    /* ===== Mirror stats table ===== */
+    var mirrorStatsSort = { key: 'disk_usage_gb', dir: 'desc' };
+    var mirrorStatsData = [];
+    var mirrorStatsLoaded = false;
+
+    function fmtMirrorType(type) {
+        var map = { full: '全量', cache: '缓存', proxy: '代理' };
+        return '<span class="type-badge ' + type + '">' + (map[type] || type) + '</span>';
+    }
+    function fmtSyncStatus(status) {
+        var map = {
+            completed: '✅ 同步完成',
+            syncing: '▶️ 同步中',
+            never: '❌ 从未同步',
+            cache: '⏩ 缓存加速'
+        };
+        return map[status] || status;
+    }
+    function fmtDiskUsage(gb, maxGb) {
+        if (gb === null || gb === undefined) return '—';
+        var pct = maxGb > 0 ? Math.min(100, (gb / maxGb) * 100) : 0;
+        return '<span class="disk-bar"><span class="disk-bar-track"><span class="disk-bar-fill" style="width:' + pct.toFixed(1) + '%;"></span></span>' + gb.toFixed(1) + ' GB</span>';
+    }
+    function renderMirrorStatsTable() {
+        var mirrors = mirrorStatsData.slice();
+        var key = mirrorStatsSort.key;
+        var dir = mirrorStatsSort.dir === 'asc' ? 1 : -1;
+        mirrors.sort(function (a, b) {
+            var va = a[key], vb = b[key];
+            if (va === null || va === undefined) va = -1;
+            if (vb === null || vb === undefined) vb = -1;
+            if (typeof va === 'string' && typeof vb === 'string') return va.localeCompare(vb) * dir;
+            return (va - vb) * dir;
+        });
+        var maxDisk = 0;
+        mirrors.forEach(function (m) { if (m.disk_usage_gb && m.disk_usage_gb > maxDisk) maxDisk = m.disk_usage_gb; });
+        var html = '';
+        mirrors.forEach(function (m) {
+            html += '<tr>'
+                + '<td class="mirror-name">' + m.name + '</td>'
+                + '<td>' + fmtMirrorType(m.type) + '</td>'
+                + '<td>' + fmtSyncStatus(m.sync_status) + '</td>'
+                + '<td>' + (m.sync_time || '—') + '</td>'
+                + '<td>' + fmtDiskUsage(m.disk_usage_gb, maxDisk) + '</td>'
+                + '<td>' + (m.total_requests > 0 ? m.total_requests.toLocaleString() : '—') + '</td>'
+                + '<td>' + (m.daily_requests > 0 ? m.daily_requests.toLocaleString() : '—') + '</td>'
+                + '</tr>';
+        });
+        document.getElementById('mirror-stats-tbody').innerHTML = html;
+        document.querySelectorAll('.mirror-stats-table th.sortable').forEach(function (th) {
+            th.classList.remove('sorted-asc', 'sorted-desc');
+            if (th.dataset.sort === key) th.classList.add(mirrorStatsSort.dir === 'asc' ? 'sorted-asc' : 'sorted-desc');
+        });
+    }
+    function bindMirrorStatsSort() {
+        document.querySelectorAll('.mirror-stats-table th.sortable').forEach(function (th) {
+            th.addEventListener('click', function () {
+                var key = th.dataset.sort;
+                if (mirrorStatsSort.key === key) {
+                    mirrorStatsSort.dir = mirrorStatsSort.dir === 'asc' ? 'desc' : 'asc';
+                } else {
+                    mirrorStatsSort.key = key;
+                    mirrorStatsSort.dir = 'asc';
+                }
+                renderMirrorStatsTable();
+            });
+        });
+    }
+    async function loadMirrorStats() {
+        if (!mirrorStatsLoaded) tableSkeleton('mirror-stats-tbody', 7);
+        try {
+            var res = await fetch('/mirror_stats.json');
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            var json = await res.json();
+            mirrorStatsData = json.mirrors || [];
+            mirrorStatsLoaded = true;
+            var timeEl = document.getElementById('mirror-stats-time');
+            if (timeEl && json.generated_at) timeEl.textContent = json.generated_at.replace('T', ' ');
+            renderMirrorStatsTable();
+        } catch (e) {
+            if (!mirrorStatsLoaded) tableEmpty('mirror-stats-tbody', '统计数据暂不可用', 7);
+        }
+    }
+
     /* ===== Harbor: Overview stat cards ===== */
     async function loadHarborOverview() {
         var sel = '{' + HARBOR_JOB + '}';
@@ -1258,7 +1342,8 @@
             loadBargauge().catch(function () {}),
             loadAggLoad().catch(function () {}),
             loadAggMem().catch(function () {}),
-            loadAggDisk().catch(function () {})
+            loadAggDisk().catch(function () {}),
+            loadMirrorStats().catch(function () {})
         ]);
         const now = new Date();
         document.getElementById('last-refresh').textContent = '上次刷新: ' +
@@ -1400,6 +1485,7 @@
                         'chart-hb-api','chart-hb-inflight','chart-hb-queue','chart-hb-latency'];
         chartIds.forEach(function (id) { chartFirstLoad.add(id); });
         bindControls();
+        bindMirrorStatsSort();
         moveIndicator(document.getElementById('time-selector'));
         moveIndicator(document.getElementById('tab-nav'));
         window.addEventListener('hashchange', function () {


### PR DESCRIPTION
## 变更内容

### 服务端：`mirror_stats_json.py`（新建）
- 每小时由 cron 运行（`0 * * * *`），聚合以下数据输出 JSON 到 `/mnt/mirror/mirror_stats.json`：
  - **磁盘占用**：`du -sb` 全量镜像（`/mnt/mirror/`）和缓存镜像（`/home/mirror/nginx_cache/`）
  - **累计请求次数**：读取 `/home/mirror/log/total.csv`
  - **当日请求次数**：读取 `/home/mirror/log/daily_YYYYMMDD.csv`
  - **同步状态**：读取 `/home/mirror/sync_time/<name>` 和 `/tmp/mirror/lock/<name>.lock`
- 复用 `mirror_index.py` 的 `cdn_mirror_list`、`ignore_dir` 分类逻辑
- 硬编码 `CACHE_DIR_MAP` 处理命名差异（如 `homebrew-bottles` → `homebrew_bottles`）
- 新镜像通过 `glob` 自动发现，天然可扩展

### 前端：状态页镜像统计表
- `status.html`：panel-mirrors 末尾追加可排序表格（镜像名称 | 类型 | 同步状态 | 最近同步 | 磁盘占用 | 累计请求 | 当日请求）
- `status.css`：sortable 列头（↕/↑/↓ 指示器）、type-badge（全量/缓存/代理）、disk-bar 进度条
- `status.js`：`fetch('/mirror_stats.json')` + 渲染表格 + 点击列头排序（默认按磁盘占用降序），null 值显示 —

### crontab
- 添加文档行：`0 * * * * /bin/python3 /home/mirror/mirrors-gdut/mirror_stats_json.py`

## 验证
- Playwright 本地验证：11 个 mock 镜像数据，表格渲染正确，排序功能正常（名称升/降序、数值升序），0 控制台错误

## 部署须知
1. 服务器上以 `mirror` 用户 `crontab -e` 添加：`0 * * * * /bin/python3 /home/mirror/mirrors-gdut/mirror_stats_json.py`
2. 首次运行后 `/mnt/mirror/mirror_stats.json` 生成，状态页自动展示