### PR TITLE
优化镜像统计脚本：N 次 du 改为 2 次批量扫描，频率降为每 2 小时

### DIFF
--- a/crontab
+++ b/crontab
@@ -27,7 +27,7 @@
 59 23 * * * /bin/python3 /home/mirror/mirror_daily_summary.py > /mnt/mirror/daily_stat.txt
 # 每周日23:30发送磁盘数据
 30 23 * * 0  /bin/python3 /home/mirror/mirror_disk_summary.py
-# 每小时整点生成镜像统计数据JSON（供status.html前端消费）
-0 * * * * /bin/python3 /home/mirror/mirrors-gdut/mirror_stats_json.py
+# 每两小时生成镜像统计数据JSON（供status.html前端消费）
+0 */2 * * * /bin/python3 /home/mirror/mirrors-gdut/mirror_stats_json.py
 # 缓存预热
 # 0 4 * * *  cd /home/mirror/tmp; python3 /home/mirror/mirrors-gdut/mirror_auto_cache.py > /tmp/mirror_auto_cache.log

--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -34,18 +34,26 @@ CACHE_DIR_MAP = {
 }
 
 
-def get_disk_usage_gb(path):
+def du_dir_map(path, timeout=600):
+    result = {}
     try:
-        result = subprocess.run(
-            ['du', '-sb', path],
-            capture_output=True, text=True, timeout=300
+        proc = subprocess.run(
+            ['du', '-sb', '--max-depth=1', path],
+            capture_output=True, text=True, timeout=timeout
         )
-        if result.returncode == 0:
-            bytes_size = int(result.stdout.split()[0])
-            return round(bytes_size / (1024 ** 3), 1)
-    except (subprocess.TimeoutExpired, ValueError, IndexError):
+        if proc.returncode == 0:
+            for line in proc.stdout.strip().split('\n'):
+                parts = line.split('\t')
+                if len(parts) == 2:
+                    name = os.path.basename(parts[1])
+                    if name and name != os.path.basename(path):
+                        try:
+                            result[name] = int(parts[0])
+                        except ValueError:
+                            pass
+    except subprocess.TimeoutExpired:
         pass
-    return None
+    return result
 
 
 def read_csv_stats():
@@ -103,6 +111,8 @@ def get_sync_info(mirror_name, is_cache):
 
 def main():
     total_stats, daily_stats = read_csv_stats()
+    mirror_disk = du_dir_map(MIRROR_DIR)
+    cache_disk = du_dir_map(CACHE_DIR)
 
     mirrors = []
     for mirror_path in sorted(glob.glob(os.path.join(MIRROR_DIR, '*'))):
@@ -120,9 +130,11 @@ def main():
             disk_usage = None
         elif is_cache:
             cache_name = CACHE_DIR_MAP.get(mirror_name, mirror_name)
-            disk_usage = get_disk_usage_gb(os.path.join(CACHE_DIR, cache_name))
+            disk_bytes = cache_disk.get(cache_name)
+            disk_usage = round(disk_bytes / (1024 ** 3), 1) if disk_bytes else None
         else:
-            disk_usage = get_disk_usage_gb(mirror_path)
+            disk_bytes = mirror_disk.get(mirror_name)
+            disk_usage = round(disk_bytes / (1024 ** 3), 1) if disk_bytes else None
 
         sync_time, sync_status = get_sync_info(mirror_name, is_cache)
 


### PR DESCRIPTION
## 问题
原脚本对每个镜像单独调用 `du -sb`（N 次 I/O 扫描），IPv4 站耗时 10+ 分钟。

## 优化
- `du_dir_map()` 用 `du -sb --max-depth=1` 一次性扫描整个父目录，替代 N 次单独 `du`
- `/mnt/mirror/` 和 `/home/mirror/nginx_cache/` 各扫描一次即可
- cron 频率从每小时改为每 2 小时（磁盘占用变化不快，同步状态由 Prometheus 60s 刷新覆盖）