### PR TITLE
修复磁盘占用为空：du -s 覆盖了 --max-depth=1

### DIFF
--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -38,7 +38,7 @@ def du_dir_map(path, timeout=600):
     result = {}
     try:
         proc = subprocess.run(
-            ['du', '-sb', '--max-depth=1', path],
+            ['du', '-b', '--max-depth=1', path],
             capture_output=True, text=True, timeout=timeout
         )
         if proc.returncode == 0:


### PR DESCRIPTION
## 问题
`du -sb --max-depth=1` 中 `-s`（summarize）与 `--max-depth=1` 冲突，`-s` 优先级更高，导致只输出父目录总计而非各子目录大小，所有镜像磁盘占用均为 null。

## 修复
去掉 `-s`，用 `du -b --max-depth=1` 即可正确输出各子目录大小。