### PR TITLE
修复全量镜像磁盘占用为空：du 遇到权限不足返回非零码导致输出被丢弃

### DIFF
--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -41,16 +41,15 @@ def du_dir_map(path, timeout=600):
             ['du', '-b', '--max-depth=1', path],
             capture_output=True, text=True, timeout=timeout
         )
-        if proc.returncode == 0:
-            for line in proc.stdout.strip().split('\n'):
-                parts = line.split('\t')
-                if len(parts) == 2:
-                    name = os.path.basename(parts[1])
-                    if name and name != os.path.basename(path):
-                        try:
-                            result[name] = int(parts[0])
-                        except ValueError:
-                            pass
+        for line in proc.stdout.strip().split('\n'):
+            parts = line.split('\t')
+            if len(parts) == 2:
+                name = os.path.basename(parts[1])
+                if name and name != os.path.basename(path):
+                    try:
+                        result[name] = int(parts[0])
+                    except ValueError:
+                        pass
     except subprocess.TimeoutExpired:
         pass
     return result


### PR DESCRIPTION
## 问题
`du` 遍历 `/mnt/mirror/` 时，遇到权限不足的子目录（如 `git`、`scripts`）会返回非零退出码，但仍输出了能访问的目录数据。原代码 `if proc.returncode == 0` 在非零时丢弃了全部输出，导致全量镜像磁盘占用为 null。缓存目录无权限问题所以正常。

## 修复
去掉 `returncode` 检查，处理 `du` 的所有可用输出。