### PR TITLE
修复全量镜像磁盘占用为空：/mnt/mirror 子目录是符号链接

### DIFF
--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -41,6 +41,12 @@ def du_dir_map(path, timeout=600):
             ['du', '-b', '--max-depth=1', path],
             capture_output=True, text=True, timeout=timeout
         )
+        print('[du_dir_map] path=%s returncode=%d stdout_lines=%d stderr_lines=%d' %
+              (path, proc.returncode, len(proc.stdout.strip().split('\n')), len(proc.stderr.strip().split('\n'))))
+        if proc.stderr.strip():
+            print('[du_dir_map] stderr (first 500 chars): ' + proc.stderr.strip()[:500])
+        if proc.stdout.strip():
+            print('[du_dir_map] stdout (first 500 chars): ' + proc.stdout.strip()[:500])
         for line in proc.stdout.strip().split('\n'):
             parts = line.split('\t')
             if len(parts) == 2:
@@ -51,7 +57,7 @@ def du_dir_map(path, timeout=600):
                     except ValueError:
                         pass
     except subprocess.TimeoutExpired:
-        pass
+        print('[du_dir_map] TIMEOUT for path=' + path)
     return result
 
 

--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -38,15 +38,9 @@ def du_dir_map(path, timeout=600):
     result = {}
     try:
         proc = subprocess.run(
-            ['du', '-b', '--max-depth=1', path],
+            ['du', '-bL', '--max-depth=1', path],
             capture_output=True, text=True, timeout=timeout
         )
-        print('[du_dir_map] path=%s returncode=%d stdout_lines=%d stderr_lines=%d' %
-              (path, proc.returncode, len(proc.stdout.strip().split('\n')), len(proc.stderr.strip().split('\n'))))
-        if proc.stderr.strip():
-            print('[du_dir_map] stderr (first 500 chars): ' + proc.stderr.strip()[:500])
-        if proc.stdout.strip():
-            print('[du_dir_map] stdout (first 500 chars): ' + proc.stdout.strip()[:500])
         for line in proc.stdout.strip().split('\n'):
             parts = line.split('\t')
             if len(parts) == 2:
@@ -57,7 +51,7 @@ def du_dir_map(path, timeout=600):
                     except ValueError:
                         pass
     except subprocess.TimeoutExpired:
-        print('[du_dir_map] TIMEOUT for path=' + path)
+        pass
     return result
 
 


### PR DESCRIPTION
## 根因
`/mnt/mirror/` 下的子目录是指向其他挂载点的符号链接。`du` 默认不跟随符号链接，把这些目录跳过或当作 0 字节，导致全量镜像磁盘占用为 null。缓存目录 `/home/mirror/nginx_cache/` 是真实目录所以正常。

## 修复
`du` 加 `-L` 参数跟随符号链接。同时移除上一次的调试输出。