### PR TITLE
将所有 Emoji 图标替换为 SVG 图标，统一设计风格

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -517,6 +517,9 @@ html.js .navbar-brand.autohide.is-visible {
     font-size: 0.875rem;
     font-weight: 500;
 }
+.status-badge .status-icon {
+    flex-shrink: 0;
+}
 
 .status-success {
     background: rgba(16, 185, 129, 0.1);

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -187,20 +187,20 @@
             const text = cell.textContent.trim();
             let badgeClass = '';
             
-            if (text.includes('同步完成') || text.includes('✅')) {
+            if (text.includes('同步完成')) {
                 badgeClass = 'status-success';
-            } else if (text.includes('同步中') || text.includes('▶️')) {
+            } else if (text.includes('同步中')) {
                 badgeClass = 'status-syncing';
-            } else if (text.includes('缓存') || text.includes('⏩')) {
+            } else if (text.includes('缓存')) {
                 badgeClass = 'status-cache';
-            } else if (text.includes('从未') || text.includes('❌')) {
+            } else if (text.includes('从未')) {
                 badgeClass = 'status-error';
             }
             
             if (badgeClass) {
                 const badge = document.createElement('span');
                 badge.className = `status-badge ${badgeClass}`;
-                badge.textContent = text;
+                badge.innerHTML = text;
                 cell.textContent = '';
                 cell.appendChild(badge);
             }

--- a/demo.html
+++ b/demo.html
@@ -107,8 +107,8 @@
                                 </svg>
                                 <a href="/ubuntu/">ubuntu</a>
                             </td>
-                            <td><code>⏱️ 2024-01-21 02:30</code></td>
-                            <td><span class="status-badge status-success">✅ 同步完成</span></td>
+                            <td><code><svg class="time-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> 2024-01-21 02:30</code></td>
+                            <td><span class="status-badge status-success"><svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成</span></td>
                             <td>12,345</td>
                             <td>
                                 <a target="_blank" href="#" style="display: inline-flex; align-items: center; gap: 4px;">
@@ -127,8 +127,8 @@
                                 </svg>
                                 <a href="/debian/">debian</a>
                             </td>
-                            <td><code>⏱️ 2024-01-21 04:15</code></td>
-                            <td><span class="status-badge status-syncing">▶️ 同步中</span></td>
+                            <td><code><svg class="time-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> 2024-01-21 04:15</code></td>
+                            <td><span class="status-badge status-syncing"><svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中</span></td>
                             <td>8,901</td>
                             <td>
                                 <a target="_blank" href="#" style="display: inline-flex; align-items: center; gap: 4px;">
@@ -147,8 +147,8 @@
                                 </svg>
                                 centos-stream
                             </td>
-                            <td><code>⛔️</code></td>
-                            <td><span class="status-badge status-cache">⏩ 缓存加速</span></td>
+                            <td><code>—</code></td>
+                            <td><span class="status-badge status-cache"><svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速</span></td>
                             <td>5,678</td>
                             <td>
                                 <a target="_blank" href="#" style="display: inline-flex; align-items: center; gap: 4px;">
@@ -167,8 +167,8 @@
                                 </svg>
                                 <a href="/archlinux/">archlinux</a>
                             </td>
-                            <td><code>⏱️ 2024-01-21 01:00</code></td>
-                            <td><span class="status-badge status-success">✅ 同步完成</span></td>
+                            <td><code><svg class="time-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> 2024-01-21 01:00</code></td>
+                            <td><span class="status-badge status-success"><svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成</span></td>
                             <td>3,456</td>
                             <td>
                                 <a target="_blank" href="#" style="display: inline-flex; align-items: center; gap: 4px;">

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -309,20 +309,20 @@ for mirror in mirror_list:
 
         # 判断镜像是否缓存镜像
         if mirror_name in cdn_mirror_list:  # 缓存镜像（nginx反向代理）
-            sync_time = '⛔️'
-            sync_status = '⏩ 缓存加速'
+            sync_time = ''
+            sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速'
             is_syncing = 'false'
         else:  # 非缓存镜像（保存在服务器硬盘）
             try:
                 with open('/home/mirror/sync_time/' + mirror_name, 'r') as f:
-                    sync_time = "⏱️ " + f.read().strip()
+                    sync_time = '<svg class="time-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> ' + f.read().strip()
                 if os.path.isfile('/tmp/mirror/lock/' + mirror_name + '.lock'):
-                    sync_status = '▶️ 同步中'
+                    sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中'
                 else:
-                    sync_status = '✅ 同步完成'
+                    sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成'
             except FileNotFoundError:
-                sync_time = '⛔️'
-                sync_status = '❌ 从未同步'
+                sync_time = ''
+                sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> 从未同步'
 
         # 生成镜像链接（缓存镜像除了docker都不显示链接）
         if mirror_name in cdn_mirror_list and mirror_name != "docker":
@@ -337,7 +337,7 @@ for mirror in mirror_list:
         else:  # odd
             row_class = 'odd'
             odd_or_even = 'even'
-        if sync_status == '▶️ 同步中':
+        if '同步中' in sync_status:
             row_class = 'syncing-row'
         # 组合成一行的HTML
         html += SECTION_TEMPLATE.substitute(row_class=row_class, mirror_link=mirror_link, mirror_name=mirror_name, sync_time=sync_time,

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -517,6 +517,9 @@ html.js .navbar-brand.autohide.is-visible {
     font-size: 0.875rem;
     font-weight: 500;
 }
+.status-badge .status-icon {
+    flex-shrink: 0;
+}
 
 .status-success {
     background: rgba(16, 185, 129, 0.1);

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -187,20 +187,20 @@
             const text = cell.textContent.trim();
             let badgeClass = '';
             
-            if (text.includes('同步完成') || text.includes('✅')) {
+            if (text.includes('同步完成')) {
                 badgeClass = 'status-success';
-            } else if (text.includes('同步中') || text.includes('▶️')) {
+            } else if (text.includes('同步中')) {
                 badgeClass = 'status-syncing';
-            } else if (text.includes('缓存') || text.includes('⏩')) {
+            } else if (text.includes('缓存')) {
                 badgeClass = 'status-cache';
-            } else if (text.includes('从未') || text.includes('❌')) {
+            } else if (text.includes('从未')) {
                 badgeClass = 'status-error';
             }
             
             if (badgeClass) {
                 const badge = document.createElement('span');
                 badge.className = `status-badge ${badgeClass}`;
-                badge.textContent = text;
+                badge.innerHTML = text;
                 cell.textContent = '';
                 cell.appendChild(badge);
             }

--- a/pages/status.css
+++ b/pages/status.css
@@ -194,6 +194,7 @@
 .type-badge.full { background: rgba(16, 185, 129, 0.15); color: var(--color-success); }
 .type-badge.cache { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
 .type-badge.proxy { background: rgba(245, 158, 11, 0.15); color: var(--color-warning); }
+.sync-icon { flex-shrink: 0; vertical-align: middle; }
 .mirror-name { font-family: 'Inter', sans-serif; font-weight: 600; color: var(--color-text); }
 .disk-bar {
     display: inline-flex;

--- a/pages/status.js
+++ b/pages/status.js
@@ -930,10 +930,10 @@
     }
     function fmtSyncStatus(status) {
         var map = {
-            completed: '✅ 同步完成',
-            syncing: '▶️ 同步中',
-            never: '❌ 从未同步',
-            cache: '⏩ 缓存加速'
+            completed: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成',
+            syncing: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中',
+            never: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> 从未同步',
+            cache: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速'
         };
         return map[status] || status;
     }


### PR DESCRIPTION
## 变更内容

将镜像站所有页面中的 Emoji 图标替换为 inline SVG，与 Island UI 设计风格统一。

### Emoji → SVG 映射
| 原 Emoji | 用途 | SVG 图标 |
|---|---|---|
| ✅ | 同步完成 | check-circle |
| ▶️ | 同步中 | refresh-circle |
| ❌ | 从未同步 | x-circle |
| ⏩ | 缓存加速 | zap（闪电） |
| ⏱️ | 同步时间 | clock |
| ⛔️ | 无同步时间 | 移除，用 — 替代 |

### 涉及文件（8 个）
- `mirror_index.py`：服务端生成 HTML 中的同步状态和同步时间
- `pages/mirror.js` + `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js`：`enhanceStatusBadges` 用 `innerHTML` 渲染 SVG，匹配条件去掉 Emoji 检测
- `pages/mirror.css` + `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css`：添加 `.status-icon` 样式
- `pages/status.js`：`fmtSyncStatus` 返回 inline SVG
- `pages/status.css`：添加 `.sync-icon` 样式
- `demo.html`：更新示例数据

### 验证
- Playwright 本地验证：状态页镜像统计表 4 种同步状态（completed/syncing/never/cache）SVG 正确渲染，0 控制台错误