### PR TITLE
修复 SVG 替换问题：首页 badge 保留 SVG、空时间显示 —、FancyIndex 目录图标、状态页上色

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/header.html
@@ -58,18 +58,40 @@
 
         /* Directory and file icons */
         .fancyindex-list a[href$="/"]::before {
-            content: "📁";
-            font-size: 1.2em;
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
 
         .fancyindex-list a:not([href$="/"])::before {
-            content: "📄";
-            font-size: 1.2em;
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
 
         /* Parent directory link */
         .fancyindex-list a[href=".."]::before {
-            content: "⬆️";
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 19V5M5 12l7-7 7 7'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
 
         /* Breadcrumb navigation */

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -184,6 +184,7 @@
     function enhanceStatusBadges() {
         const statusCells = document.querySelectorAll('#distro-table td:nth-child(3)');
         statusCells.forEach(cell => {
+            const html = cell.innerHTML.trim();
             const text = cell.textContent.trim();
             let badgeClass = '';
             
@@ -200,7 +201,7 @@
             if (badgeClass) {
                 const badge = document.createElement('span');
                 badge.className = `status-badge ${badgeClass}`;
-                badge.innerHTML = text;
+                badge.innerHTML = html;
                 cell.textContent = '';
                 cell.appendChild(badge);
             }

--- a/fancyindex-demo.html
+++ b/fancyindex-demo.html
@@ -52,18 +52,40 @@
         
         /* Directory and file icons */
         .fancyindex-list a[href$="/"]::before {
-            content: "📁";
-            font-size: 1.2em;
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
         
         .fancyindex-list a:not([href$="/"])::before {
-            content: "📄";
-            font-size: 1.2em;
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
         
         /* Parent directory link */
         .fancyindex-list a[href=".."]::before {
-            content: "⬆️";
+            content: '';
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23718096' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M12 19V5M5 12l7-7 7 7'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
         }
         
         /* Breadcrumb navigation */
@@ -124,7 +146,7 @@
                 
                 <!-- Breadcrumb navigation -->
                 <div class="breadcrumb">
-                    <a href="/">🏠 首页</a>
+                    <a href="/"><svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="display:inline;vertical-align:middle;"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg> 首页</a>
                     <span class="breadcrumb-separator">/</span>
                     <a href="/ubuntu/">ubuntu</a>
                     <span class="breadcrumb-separator">/</span>

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -309,7 +309,7 @@ for mirror in mirror_list:
 
         # 判断镜像是否缓存镜像
         if mirror_name in cdn_mirror_list:  # 缓存镜像（nginx反向代理）
-            sync_time = ''
+            sync_time = '—'
             sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速'
             is_syncing = 'false'
         else:  # 非缓存镜像（保存在服务器硬盘）
@@ -321,7 +321,7 @@ for mirror in mirror_list:
                 else:
                     sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成'
             except FileNotFoundError:
-                sync_time = ''
+                sync_time = '—'
                 sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> 从未同步'
 
         # 生成镜像链接（缓存镜像除了docker都不显示链接）

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -184,6 +184,7 @@
     function enhanceStatusBadges() {
         const statusCells = document.querySelectorAll('#distro-table td:nth-child(3)');
         statusCells.forEach(cell => {
+            const html = cell.innerHTML.trim();
             const text = cell.textContent.trim();
             let badgeClass = '';
             
@@ -200,7 +201,7 @@
             if (badgeClass) {
                 const badge = document.createElement('span');
                 badge.className = `status-badge ${badgeClass}`;
-                badge.innerHTML = text;
+                badge.innerHTML = html;
                 cell.textContent = '';
                 cell.appendChild(badge);
             }

--- a/pages/status.css
+++ b/pages/status.css
@@ -195,6 +195,11 @@
 .type-badge.cache { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
 .type-badge.proxy { background: rgba(245, 158, 11, 0.15); color: var(--color-warning); }
 .sync-icon { flex-shrink: 0; vertical-align: middle; }
+.sync-text { display: inline-flex; align-items: center; gap: 4px; font-weight: 500; }
+.sync-ok { color: var(--color-success); }
+.sync-run { color: var(--color-syncing); }
+.sync-cac { color: var(--color-info); }
+.sync-err { color: var(--color-error); }
 .mirror-name { font-family: 'Inter', sans-serif; font-weight: 600; color: var(--color-text); }
 .disk-bar {
     display: inline-flex;

--- a/pages/status.js
+++ b/pages/status.js
@@ -930,10 +930,10 @@
     }
     function fmtSyncStatus(status) {
         var map = {
-            completed: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成',
-            syncing: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中',
-            never: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> 从未同步',
-            cache: '<svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速'
+            completed: '<span class="sync-text sync-ok"><svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成</span>',
+            syncing: '<span class="sync-text sync-run"><svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中</span>',
+            never: '<span class="sync-text sync-err"><svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> 从未同步</span>',
+            cache: '<span class="sync-text sync-cac"><svg class="sync-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg> 缓存加速</span>'
         };
         return map[status] || status;
     }


### PR DESCRIPTION
## 修复 4 个问题

### 1. 首页同步状态 SVG 丢失
`enhanceStatusBadges()` 用 `cell.textContent` 读取内容会剥掉 SVG 标签，导致只保留文字。改用 `cell.innerHTML` 读取，`badge.innerHTML = html` 写入，完整保留 SVG。

### 2. 同步时间为空的行没有占位符
`mirror_index.py` 中缓存镜像和从未同步的 `sync_time` 从空字符串改为 `—`。

### 3. FancyIndex 目录图标仍是 Emoji
`header.html` 中 `📁` `📄` `⬆️` 替换为 SVG data URI（CSS `content` 不能直接放 SVG 标签，用 `background-image` 实现）。`fancyindex-demo.html` 同步更新。

### 4. 状态页同步状态 SVG 没有上色
给 `fmtSyncStatus` 返回的 HTML 加 `.sync-text` 包裹和颜色 class：
- 同步完成 `.sync-ok` = 绿色 `#10b981`
- 同步中 `.sync-run` = 紫色 `#8b5cf6`
- 缓存加速 `.sync-cac` = 蓝色 `#3b82f6`
- 从未同步 `.sync-err` = 红色 `#ef4444`

### 验证
- Playwright 验证状态页 4 种状态颜色正确（rgb 值匹配），0 控制台错误
- 全项目 grep 确认 0 Emoji 残留