### PR TITLE
切回逐个镜像 du -sbL 扫描，每扫一个打印日志

### DIFF
--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -40,13 +40,13 @@ def log(msg):
     print('[%s] %s' % (datetime.now().strftime('%Y-%m-%d %H:%M:%S'), msg), flush=True)
 
 
-def du_dir_map(path, timeout=600):
+def du_dir_map(path, timeout=120):
     result = {}
-    log('du_dir_map: 开始扫描 %s' % path)
+    log('du_dir_map: 开始批量扫描 %s' % path)
     start = time.time()
     try:
         proc = subprocess.run(
-            ['du', '-bL', '--max-depth=1', path],
+            ['du', '-b', '--max-depth=1', path],
             capture_output=True, text=True, timeout=timeout
         )
         elapsed = time.time() - start
@@ -69,6 +69,27 @@ def du_dir_map(path, timeout=600):
     except subprocess.TimeoutExpired:
         log('du_dir_map: %s 超时（%ds）' % (path, timeout))
     return result
+
+
+def du_single(path, timeout=600):
+    start = time.time()
+    try:
+        proc = subprocess.run(
+            ['du', '-sbL', path],
+            capture_output=True, text=True, timeout=timeout
+        )
+        elapsed = time.time() - start
+        if proc.stdout.strip():
+            bytes_size = int(proc.stdout.split()[0])
+            gb = round(bytes_size / (1024 ** 3), 1)
+            log('  du %s: %.1f GB (%.1fs)' % (os.path.basename(path), gb, elapsed))
+            return gb
+        log('  du %s: 无输出 (%.1fs)' % (os.path.basename(path), elapsed))
+    except subprocess.TimeoutExpired:
+        log('  du %s: 超时（%ds）' % (os.path.basename(path), timeout))
+    except (ValueError, IndexError):
+        log('  du %s: 解析失败' % os.path.basename(path))
+    return None
 
 
 def read_csv_stats():
@@ -132,9 +153,9 @@ def main():
     overall_start = time.time()
 
     total_stats, daily_stats = read_csv_stats()
-    mirror_disk = du_dir_map(MIRROR_DIR)
     cache_disk = du_dir_map(CACHE_DIR)
 
+    log('开始逐个扫描全量镜像目录（-L 跟随符号链接）')
     mirrors = []
     skipped = 0
     for mirror_path in sorted(glob.glob(os.path.join(MIRROR_DIR, '*'))):
@@ -156,11 +177,7 @@ def main():
             disk_bytes = cache_disk.get(cache_name)
             disk_usage = round(disk_bytes / (1024 ** 3), 1) if disk_bytes else None
         else:
-            disk_bytes = mirror_disk.get(mirror_name)
-            disk_usage = round(disk_bytes / (1024 ** 3), 1) if disk_bytes else None
-
-        if not is_proxy and disk_usage is None:
-            log('警告: %s 磁盘占用为空 (type=%s)' % (mirror_name, 'cache' if is_cache else 'full'))
+            disk_usage = du_single(mirror_path)
 
         sync_time, sync_status = get_sync_info(mirror_name, is_cache)
 


### PR DESCRIPTION
## 问题
V4 批量 `du -bL --max-depth=1 /mnt/mirror` 超时 600s（`-L` 跟随符号链接后数据量太大，V4 有大量全量镜像）。

## 修复
- 全量镜像：改回逐个 `du -sbL <path>` 调用，每个镜像单独超时 600s，虽然慢但有结果
- 缓存目录：保持批量 `du -b --max-depth=1`（真实目录，不是符号链接，不会超时）
- `du_dir_map` 超时从 600s 降为 120s（仅用于缓存目录）

## 日志
`du_single()` 每扫一个镜像打印：名称、大小（GB）、耗时。示例：
```
[2026-07-24 19:02:23] 开始逐个扫描全量镜像目录（-L 跟随符号链接）
[2026-07-24 19:02:25]   du CTAN: 5.2 GB (2.1s)
[2026-07-24 19:02:30]   du archlinux: 45.3 GB (5.2s)
[2026-07-24 19:03:15]   du ubuntu: 142.3 GB (45.1s)
...
```