### PR TITLE
修复主页同步时间 SVG 图标偏上

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -125,7 +125,7 @@ SECTION_TEMPLATE = Template("""
                             </svg>
                             ${mirror_link}
                         </td>
-                        <td><code>${sync_time}</code></td>
+                        <td><code style="display: inline-flex; align-items: center; gap: 4px;">${sync_time}</code></td>
                         <td>${sync_status}</td>
                         <td>${download_count}</td>
                         <td>


### PR DESCRIPTION
## 问题
同步时间列的 SVG 时钟图标比文字偏上，`vertical-align: middle` 在行内 `<code>` 元素中对齐不准。

## 修复
`<code>` 标签设 `display: inline-flex; align-items: center; gap: 4px`，SVG 和文字在 flex 容器中垂直居中。

## 验证（Playwright）
- SVG 中心 Y = 73.78，文字中心 Y = 73.09，偏差 0.69px（几乎完美）
- 0 控制台错误