### PR TITLE
同步中状态图标添加旋转动画

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -546,6 +546,15 @@ html.js .navbar-brand.autohide.is-visible {
     background: rgba(139, 92, 246, 0.05) !important;
 }
 
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.status-icon.syncing {
+    animation: spin 1s linear infinite;
+}
+
 .even {
     background: transparent;
 }

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -317,7 +317,7 @@ for mirror in mirror_list:
                 with open('/home/mirror/sync_time/' + mirror_name, 'r') as f:
                     sync_time = '<svg class="time-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> ' + f.read().strip()
                 if os.path.isfile('/tmp/mirror/lock/' + mirror_name + '.lock'):
-                    sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中'
+                    sync_status = '<svg class="status-icon syncing" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12a9 9 0 11-6.219-8.56"/><path d="M21 3v6h-6"/></svg> 同步中'
                 else:
                     sync_status = '<svg class="status-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> 同步完成'
             except FileNotFoundError:

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -546,6 +546,15 @@ html.js .navbar-brand.autohide.is-visible {
     background: rgba(139, 92, 246, 0.05) !important;
 }
 
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.status-icon.syncing {
+    animation: spin 1s linear infinite;
+}
+
 .even {
     background: transparent;
 }

--- a/pages/status.css
+++ b/pages/status.css
@@ -198,6 +198,7 @@
 .sync-text { display: inline-flex; align-items: center; gap: 4px; font-weight: 500; }
 .sync-ok { color: var(--color-success); }
 .sync-run { color: var(--color-syncing); }
+.sync-run .sync-icon { animation: spin 1s linear infinite; }
 .sync-cac { color: var(--color-info); }
 .sync-err { color: var(--color-error); }
 .mirror-name { font-family: 'Inter', sans-serif; font-weight: 600; color: var(--color-text); }


### PR DESCRIPTION
## 变更内容

主页镜像列表和状态页镜像统计表中，同步状态为「同步中」的 SVG 图标添加旋转动画，直观表示同步进行中。

### 修改文件

| 文件 | 变更 |
|------|------|
| `mirror_index.py` | 同步中 SVG 添加 `syncing` class |
| `pages/mirror.css` | 新增 `@keyframes spin` + `.status-icon.syncing` 规则 |
| `pages/status.css` | 新增 `.sync-run .sync-icon` 旋转动画 |
| `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css` | 与 `pages/mirror.css` 同步 |

### Playwright 验证

- 同步中图标: `animation-name: spin`, `1s`, `linear`, `infinite` ✅
- 同步完成图标: `animation-name: none`（不旋转）✅
- 状态页 `.sync-run .sync-icon`: `animation-name: spin` ✅
- 主页 `.status-icon.syncing`: `animation-name: spin` ✅