### PR TITLE
修复搜索框 hover 阴影为直角矩形

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -323,6 +323,7 @@ html.js .navbar-brand.autohide.is-visible {
 .search-box {
     position: relative;
     width: 100%;
+    border-radius: var(--radius-xl);
     transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -323,6 +323,7 @@ html.js .navbar-brand.autohide.is-visible {
 .search-box {
     position: relative;
     width: 100%;
+    border-radius: var(--radius-xl);
     transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 


### PR DESCRIPTION
## 问题

搜索框 hover 浮起时，阴影呈直角矩形，与搜索框的圆角不匹配。

## 根因

`.search-box` 是包裹 `<input>` 的 `div`，hover 时添加了 `box-shadow: var(--shadow-lg)`，但本身没有设置 `border-radius`。而 `border-radius` 只在内部的 `.search-input` 上，导致外层 div 的阴影是直角的。

## 修复

给 `.search-box` 添加 `border-radius: var(--radius-xl)`，使阴影跟随圆角。

## Playwright 验证

- hover 前: `border-radius: 32px`, `box-shadow: none` ✅
- hover 后: `border-radius: 32px`, `box-shadow: rgba(0,0,0,0.08) 0px 8px 32px 0px` ✅