### PR TITLE
为顶栏、底栏和岛添加鼠标光斑跟随效果

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -427,6 +427,36 @@ html.js .navbar-brand.autohide.is-visible {
     opacity: 1;
 }
 
+/* ==========================================
+   Spotlight Effect (光斑跟随鼠标)
+   ========================================== */
+
+.navbar::after,
+.island::after,
+#footer::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 0;
+}
+
+.navbar:hover::after,
+.island:hover::after,
+#footer:hover::after {
+    opacity: 1;
+}
+
+.dark-theme .navbar::after,
+.dark-theme .island::after,
+.dark-theme #footer::after {
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
+}
+
 .island-header {
     display: flex;
     align-items: center;
@@ -646,6 +676,8 @@ ul {
    ========================================== */
 
 #footer {
+    position: relative;
+    overflow: hidden;
     margin-top: var(--spacing-3xl);
     padding: var(--spacing-xl) var(--spacing-xl) var(--spacing-lg);
     text-align: center;

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -258,6 +258,24 @@
     }
 
     // ==========================================
+    // Spotlight Effect (光斑跟随鼠标)
+    // ==========================================
+
+    function initSpotlight() {
+        function onMouseMove(e) {
+            const el = e.target.closest('.navbar, .island, #footer');
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            const x = (e.clientX - rect.left) / rect.width * 100;
+            const y = (e.clientY - rect.top) / rect.height * 100;
+            el.style.setProperty('--mouse-x', x + '%');
+            el.style.setProperty('--mouse-y', y + '%');
+        }
+
+        document.addEventListener('mousemove', onMouseMove);
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -268,6 +286,7 @@
         enhanceTable();
         initSmoothScroll();
         initNavbarBrandVisibility();
+        initSpotlight();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -427,6 +427,36 @@ html.js .navbar-brand.autohide.is-visible {
     opacity: 1;
 }
 
+/* ==========================================
+   Spotlight Effect (光斑跟随鼠标)
+   ========================================== */
+
+.navbar::after,
+.island::after,
+#footer::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 0;
+}
+
+.navbar:hover::after,
+.island:hover::after,
+#footer:hover::after {
+    opacity: 1;
+}
+
+.dark-theme .navbar::after,
+.dark-theme .island::after,
+.dark-theme #footer::after {
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
+}
+
 .island-header {
     display: flex;
     align-items: center;
@@ -646,6 +676,8 @@ ul {
    ========================================== */
 
 #footer {
+    position: relative;
+    overflow: hidden;
     margin-top: var(--spacing-3xl);
     padding: var(--spacing-xl) var(--spacing-xl) var(--spacing-lg);
     text-align: center;

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -258,6 +258,24 @@
     }
 
     // ==========================================
+    // Spotlight Effect (光斑跟随鼠标)
+    // ==========================================
+
+    function initSpotlight() {
+        function onMouseMove(e) {
+            const el = e.target.closest('.navbar, .island, #footer');
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            const x = (e.clientX - rect.left) / rect.width * 100;
+            const y = (e.clientY - rect.top) / rect.height * 100;
+            el.style.setProperty('--mouse-x', x + '%');
+            el.style.setProperty('--mouse-y', y + '%');
+        }
+
+        document.addEventListener('mousemove', onMouseMove);
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -268,6 +286,7 @@
         enhanceTable();
         initSmoothScroll();
         initNavbarBrandVisibility();
+        initSpotlight();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();


### PR DESCRIPTION
## 变更内容

参考文档中心 (mirrors.gdut.edu.cn/help) 的光斑效果实现，为主页、FancyIndex 目录页和状态页的顶栏 (.navbar)、底栏 (#footer) 和所有岛 (.island) 添加鼠标光斑跟随效果。

### 实现方式

CSS (mirror.css)：
- .navbar、.island、#footer 添加 ::after 伪元素
- 使用 radial-gradient(circle 200px at var(--mouse-x) var(--mouse-y), rgba(255,255,255,0.12), transparent 70%)
- 默认 opacity: 0，hover 时 opacity: 1，transition: opacity 0.3s
- 深色主题降低透明度至 0.08
- #footer 补充 position: relative; overflow: hidden

JS (mirror.js)：
- 新增 initSpotlight() 函数
- 监听 document 的 mousemove 事件
- 使用 e.target.closest() 找到最近的 .navbar/.island/#footer 元素
- 计算鼠标在元素内的百分比位置，设置 --mouse-x/--mouse-y CSS 变量

### 修改文件

| 文件 | 变更 |
|------|------|
| pages/mirror.css | 添加光斑伪元素 CSS + #footer position/overflow |
| pages/mirror.js | 新增 initSpotlight() 函数 |
| Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css | 与 pages/mirror.css 同步 |
| Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js | 与 pages/mirror.js 同步 |

### Playwright 验证

- ::after 伪元素存在，默认 opacity: 0 ✅
- hover 后 opacity: 1 ✅
- mousemove 正确设置 --mouse-x: 12.82%、--mouse-y: 41.10% ✅
- border-radius: inherit 使光斑跟随圆角 ✅
- 深色主题使用降低的透明度 ✅
