### PR TITLE
修复移动端镜像列表无法左右滚动

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -863,7 +863,7 @@ p.answer {
     }
     
     /* Make table horizontally scrollable on mobile */
-    .island-main {
+    .bento-main .island {
         overflow-x: auto;
     }
     

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -863,7 +863,7 @@ p.answer {
     }
     
     /* Make table horizontally scrollable on mobile */
-    .island-main {
+    .bento-main .island {
         overflow-x: auto;
     }
     


### PR DESCRIPTION
## 问题

移动端下镜像列表表格由于列数多（5列）且设置了 `min-width: 600px`，超出视口宽度，但无法左右滚动。

## 根因

移动端 `@media (max-width: 768px)` 规则中，滚动容器选择器写为 `.island-main`，但 HTML 中实际的 class 结构是 `.bento-main > .island > #distro-table`，不存在 `.island-main`，导致 `overflow-x: auto` 从未生效。

## 修复

将选择器从 `.island-main` 改为 `.bento-main .island`，覆盖 `.island` 默认的 `overflow: hidden`。

## Playwright 验证（375px 移动端视口）

- `overflow-x: auto` ✅
- `table min-width: 600px`（超出 375px 视口）✅
- `scrollWidth: 648 > clientWidth: 341` → 可滚动 ✅
