### PR TITLE
添加统一风格的自定义错误页面

### DIFF
--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -115,6 +115,17 @@ server {
     fancyindex_footer /Nginx-Fancyindex-Theme/gdut-mirrors/footer.html;
     charset utf-8;
 
+    # 自定义错误页面
+    error_page 403 = /error.html?code=403;
+    error_page 404 = /error.html?code=404;
+    error_page 500 = /error.html?code=500;
+    error_page 502 = /error.html?code=502;
+    error_page 503 = /error.html?code=503;
+    error_page 504 = /error.html?code=504;
+    location = /error.html {
+        internal;
+    }
+
     # location 匹配顺序： 精确匹配（=） > 普通匹配（非/结尾的完整路径） > 常规字符串开头（^~） > 正则（~区分大小写 ~*不区分大小写 匹配成功就停止匹配） > 最长字符串（会遍历location再进行判断）
 
     # 最后匹配，没有匹配到缓存URL的就访问本地文件

--- a/pages/error.html
+++ b/pages/error.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
+    <link rel="stylesheet" type="text/css" href="/mirror.css" media="screen"/>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <title>页面未找到 - 广东工业大学开源镜像站</title>
+</head>
+
+<body class="fade-in">
+
+<nav class="navbar">
+    <div class="navbar-container">
+        <a href="/" class="navbar-brand">
+            <img src="/GDUT_Logo.png" alt="GDUT Logo">
+            <span>GDUT 开源镜像站</span>
+        </a>
+        <div class="navbar-actions">
+            <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">
+                <svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+                </svg>
+            </button>
+        </div>
+    </div>
+</nav>
+
+<main class="main-container">
+    <div class="bento-grid">
+        <div class="bento-main" style="grid-column: span 12;">
+            <div class="island" style="text-align: center; padding: var(--spacing-3xl) var(--spacing-xl);">
+                <svg class="island-icon" width="64" height="64" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" style="margin: 0 auto var(--spacing-lg); color: var(--color-text-muted);">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                    <line x1="12" y1="9" x2="12" y2="13"></line>
+                    <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                </svg>
+                <h1 id="error-code" style="font-size: 3rem; font-weight: 800; color: var(--color-primary); margin-bottom: var(--spacing-sm);">404</h1>
+                <p id="error-message" style="font-size: 1.25rem; color: var(--color-text); margin-bottom: var(--spacing-xl);">页面未找到</p>
+                <p style="color: var(--color-text-muted); margin-bottom: var(--spacing-xl);">您访问的页面不存在或已被移除。</p>
+                <a href="/" style="display: inline-flex; align-items: center; gap: 8px; padding: var(--spacing-md) var(--spacing-xl); background: var(--gradient-primary); color: white; border-radius: var(--radius-xl); font-weight: 600; text-decoration: none; transition: all var(--transition-base);">
+                    <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                        <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                    </svg>
+                    返回首页
+                </a>
+            </div>
+        </div>
+    </div>
+</main>
+
+<footer id="footer">
+    <div>
+        <a target="_blank" href="http://www.gdut.edu.cn/">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
+            </svg>
+            广东工业大学首页
+        </a>
+        &nbsp;|&nbsp;
+        <a href="/about.html">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+            </svg>
+            关于我们
+        </a>
+        &nbsp;|&nbsp;
+        <a href="mailto:stunic@gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/>
+                <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/>
+            </svg>
+            联系我们
+        </a>
+        &nbsp;|&nbsp;
+        <a target="_blank" href="/status.html">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+            </svg>
+            当前状态
+        </a>
+        &nbsp;|&nbsp;
+        <a target="_blank" rel="noopener noreferrer" href="https://registry.gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s7-1.343-7-3z"/>
+                <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
+                <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
+            </svg>
+            容器镜像库
+        </a>
+        &nbsp;|&nbsp;
+        <a target="_blank" href="https://speed.gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
+            </svg>
+            校内测速
+        </a>
+    </div>
+    <div style="margin-top: 12px; font-size: 0.875rem; color: var(--color-text-muted);">
+        © <span id="copyright-year"></span> 广东工业大学学生网管队 | Powered by Island UI
+    </div>
+</footer>
+
+<script type="text/javascript" src="/mirror.js"></script>
+<script>
+(function() {
+    var params = new URLSearchParams(window.location.search);
+    var code = params.get('code') || '404';
+    var messages = {
+        '403': '禁止访问',
+        '404': '页面未找到',
+        '500': '服务器内部错误',
+        '502': '网关错误',
+        '503': '服务不可用',
+        '504': '网关超时'
+    };
+    var msg = messages[code] || '未知错误';
+    document.getElementById('error-code').textContent = code;
+    document.getElementById('error-message').textContent = msg;
+    document.title = code + ' ' + msg + ' - 广东工业大学开源镜像站';
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 变更内容

Nginx 默认的 404/403/5xx 错误页面风格与镜像站不一致。新增自定义错误页面，统一 Island UI 风格。

### 新增文件

**pages/error.html** — 通用错误页面：
- 复用 Island UI 设计系统（navbar + island + footer）
- 包含主题切换按钮（浅色/深色）
- 警告三角 SVG 图标 + 大号错误码 + 错误描述 + 返回首页按钮
- JS 根据 URL 参数 `?code=xxx` 动态显示对应状态码和消息
- 支持 403/404/500/502/503/504 六种错误码

### 修改文件

**nginx_conf/conf/mirror/mirror.conf** — 添加 error_page 指令：
- `error_page 403 = /error.html?code=403`
- `error_page 404 = /error.html?code=404`
- `error_page 500/502/503/504 = /error.html?code=xxx`（分别声明）
- `location = /error.html { internal; }` 标记为内部重定向，用户无法直接访问

### Playwright 验证

- 404: code=404, message=页面未找到, title 正确 ✅
- 503: code=503, message=服务不可用, title 正确 ✅
- 深色主题切换正常 ✅
- navbar/footer/island 均存在 ✅
