### PR TITLE
统一导航栏品牌名称为「广东工业大学开源镜像站」

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -15,7 +15,7 @@
     <div class="navbar-container">
         <a href="/" class="navbar-brand">
             <img src="pages/GDUT_Logo.png" alt="GDUT Logo">
-            <span>GDUT 开源镜像站</span>
+            <span>广东工业大学开源镜像站</span>
         </a>
         <div class="navbar-actions">
             <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">

--- a/fancyindex-demo.html
+++ b/fancyindex-demo.html
@@ -116,7 +116,7 @@
     <div class="navbar-container">
         <a href="/" class="navbar-brand">
             <img src="pages/GDUT_Logo.png" alt="GDUT Logo">
-            <span>GDUT 开源镜像站</span>
+            <span>广东工业大学开源镜像站</span>
         </a>
         <div class="navbar-actions">
             <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">

--- a/mirror_render_help_pages.py
+++ b/mirror_render_help_pages.py
@@ -22,7 +22,7 @@ HEADER = """
     <div class="navbar-container">
         <a href="/" class="navbar-brand">
             <img src="/pages/GDUT_Logo.png" alt="GDUT Logo">
-            <span>GDUT 开源镜像站</span>
+            <span>广东工业大学开源镜像站</span>
         </a>
         <div class="navbar-actions">
             <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">

--- a/pages/about.html
+++ b/pages/about.html
@@ -16,7 +16,7 @@
     <div class="navbar-container">
         <a href="/" class="navbar-brand">
             <img src="/GDUT_Logo.png" alt="GDUT Logo">
-            <span>GDUT 开源镜像站</span>
+            <span>广东工业大学开源镜像站</span>
         </a>
         <div class="navbar-actions">
             <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">

--- a/pages/error.html
+++ b/pages/error.html
@@ -15,7 +15,7 @@
     <div class="navbar-container">
         <a href="/" class="navbar-brand">
             <img src="/GDUT_Logo.png" alt="GDUT Logo">
-            <span>GDUT 开源镜像站</span>
+            <span>广东工业大学开源镜像站</span>
         </a>
         <div class="navbar-actions">
             <button class="theme-toggle" aria-label="切换主题" title="切换深色/浅色主题">


### PR DESCRIPTION
## 变更内容

以下文件的导航栏品牌名从缩写「GDUT 开源镜像站」统一为全称「广东工业大学开源镜像站」：

- `pages/error.html`
- `pages/about.html`
- `mirror_render_help_pages.py`（帮助页模板）
- `demo.html`
- `fancyindex-demo.html`

`pages/status.html` 和 `Nginx-Fancyindex-Theme/gdut-mirrors/header.html` 此前已是全称，无需修改。
