### PR TITLE
优化搜索框聚焦/失焦动画过渡

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -341,7 +341,8 @@ html.js .navbar-brand.autohide.is-visible {
     background: var(--color-surface);
     color: var(--color-text);
     box-shadow: var(--shadow-md);
-    transition: all var(--transition-fast);
+    transition: border-color 300ms cubic-bezier(0.22, 1, 0.36, 1),
+                box-shadow 300ms cubic-bezier(0.22, 1, 0.36, 1);
     outline: none;
 }
 

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -341,7 +341,8 @@ html.js .navbar-brand.autohide.is-visible {
     background: var(--color-surface);
     color: var(--color-text);
     box-shadow: var(--shadow-md);
-    transition: all var(--transition-fast);
+    transition: border-color 300ms cubic-bezier(0.22, 1, 0.36, 1),
+                box-shadow 300ms cubic-bezier(0.22, 1, 0.36, 1);
     outline: none;
 }
 


### PR DESCRIPTION
## 问题

搜索框在鼠标选中（focus）和失焦（blur）时的激活动画过于生硬。

## 修复

将 `.search-input` 的 `transition` 从 `all var(--transition-fast)`（150ms）改为针对 `border-color` 和 `box-shadow` 的专用过渡：

| 属性 | 修改前 | 修改后 |
|------|--------|--------|
| transition-property | `all` | `border-color, box-shadow` |
| transition-duration | 150ms | 300ms |
| transition-timing-function | `cubic-bezier(0.4, 0, 0.2, 1)` | `cubic-bezier(0.22, 1, 0.36, 1)` |

`cubic-bezier(0.22, 1, 0.36, 1)` 是 ease-out-quint 缓动曲线，起始快速、收尾平滑，适合焦点环的展开和收缩动画。

## 同步

`pages/mirror.css` 和 `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css` 两份副本同步修改。

## 验证

- Playwright 验证 transition 样式：`border-color, box-shadow` / `0.3s` / `cubic-bezier(0.22, 1, 0.36, 1)` ✅
- 聚焦状态：`border-color` 变为 `rgb(151, 25, 67)`，`box-shadow` 包含 4px 焦点环 ✅
- 失焦状态：恢复为默认 `border-color` 和 `shadow-md`，焦点环消失 ✅
- 两份 CSS 文件 diff 为空（完全同步）✅
