### PR TITLE
navbar 全宽布局 + 主题切换三态模式（浅色/深色/跟随系统）

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -208,8 +208,6 @@ a:hover {
 }
 
 .navbar-container {
-    max-width: 1400px;
-    margin: 0 auto;
     padding: var(--spacing-md) var(--spacing-xl);
     display: flex;
     align-items: center;

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -11,48 +11,55 @@
     // ==========================================
     
     const THEME_STORAGE_KEY = 'gdut-mirror-theme';
-    
+    const THEME_MODES = ['light', 'dark', 'auto'];
+    var systemDarkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+    var systemThemeHandler = null;
+
+    function applyTheme(mode) {
+        var isDark = mode === 'dark' || (mode === 'auto' && systemDarkMedia.matches);
+        document.body.classList.toggle('dark-theme', isDark);
+        document.body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
+        setTimeout(function () { document.body.style.transition = ''; }, 300);
+        updateThemeToggleIcon(document.querySelector('.theme-toggle'), mode);
+    }
+
     function initTheme() {
-        // Check stored preference or system preference
-        const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        
-        const isDark = storedTheme === 'dark' || (!storedTheme && prefersDark);
-        
-        if (isDark) {
-            document.body.classList.add('dark-theme');
-        }
-        
-        // Create theme toggle button if it exists
-        const themeToggle = document.querySelector('.theme-toggle');
+        var stored = localStorage.getItem(THEME_STORAGE_KEY);
+        var mode = THEME_MODES.indexOf(stored) >= 0 ? stored : 'auto';
+
+        applyTheme(mode);
+
+        var themeToggle = document.querySelector('.theme-toggle');
         if (themeToggle) {
-            updateThemeToggleIcon(themeToggle, isDark);
             themeToggle.addEventListener('click', toggleTheme);
         }
+
+        systemThemeHandler = function () {
+            var current = localStorage.getItem(THEME_STORAGE_KEY);
+            if (current === 'auto' || !current) applyTheme('auto');
+        };
+        systemDarkMedia.addEventListener('change', systemThemeHandler);
     }
-    
+
     function toggleTheme() {
-        const body = document.body;
-        const isDark = body.classList.toggle('dark-theme');
-        
-        localStorage.setItem(THEME_STORAGE_KEY, isDark ? 'dark' : 'light');
-        
-        const themeToggle = document.querySelector('.theme-toggle');
-        if (themeToggle) {
-            updateThemeToggleIcon(themeToggle, isDark);
-        }
-        
-        // Add smooth transition
-        body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
-        setTimeout(() => {
-            body.style.transition = '';
-        }, 300);
+        var current = localStorage.getItem(THEME_STORAGE_KEY);
+        var idx = THEME_MODES.indexOf(current);
+        if (idx < 0) idx = 2;
+        var next = THEME_MODES[(idx + 1) % THEME_MODES.length];
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+        applyTheme(next);
     }
-    
-    function updateThemeToggleIcon(button, isDark) {
-        button.innerHTML = isDark 
-            ? '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/></svg>'
-            : '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>';
+
+    function updateThemeToggleIcon(button, mode) {
+        if (!button) return;
+        var icons = {
+            light: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/></svg>',
+            dark: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>',
+            auto: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a8 8 0 100 16 8 8 0 000-16zm0 2a6 6 0 010 12V4z"/></svg>'
+        };
+        var labels = { light: '浅色模式（点击切换到深色）', dark: '深色模式（点击切换到自动）', auto: '跟随系统（点击切换到浅色）' };
+        button.innerHTML = icons[mode] || icons.auto;
+        button.title = labels[mode] || labels.auto;
     }
 
     // ==========================================

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -208,8 +208,6 @@ a:hover {
 }
 
 .navbar-container {
-    max-width: 1400px;
-    margin: 0 auto;
     padding: var(--spacing-md) var(--spacing-xl);
     display: flex;
     align-items: center;

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -11,48 +11,55 @@
     // ==========================================
     
     const THEME_STORAGE_KEY = 'gdut-mirror-theme';
-    
+    const THEME_MODES = ['light', 'dark', 'auto'];
+    var systemDarkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+    var systemThemeHandler = null;
+
+    function applyTheme(mode) {
+        var isDark = mode === 'dark' || (mode === 'auto' && systemDarkMedia.matches);
+        document.body.classList.toggle('dark-theme', isDark);
+        document.body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
+        setTimeout(function () { document.body.style.transition = ''; }, 300);
+        updateThemeToggleIcon(document.querySelector('.theme-toggle'), mode);
+    }
+
     function initTheme() {
-        // Check stored preference or system preference
-        const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        
-        const isDark = storedTheme === 'dark' || (!storedTheme && prefersDark);
-        
-        if (isDark) {
-            document.body.classList.add('dark-theme');
-        }
-        
-        // Create theme toggle button if it exists
-        const themeToggle = document.querySelector('.theme-toggle');
+        var stored = localStorage.getItem(THEME_STORAGE_KEY);
+        var mode = THEME_MODES.indexOf(stored) >= 0 ? stored : 'auto';
+
+        applyTheme(mode);
+
+        var themeToggle = document.querySelector('.theme-toggle');
         if (themeToggle) {
-            updateThemeToggleIcon(themeToggle, isDark);
             themeToggle.addEventListener('click', toggleTheme);
         }
+
+        systemThemeHandler = function () {
+            var current = localStorage.getItem(THEME_STORAGE_KEY);
+            if (current === 'auto' || !current) applyTheme('auto');
+        };
+        systemDarkMedia.addEventListener('change', systemThemeHandler);
     }
-    
+
     function toggleTheme() {
-        const body = document.body;
-        const isDark = body.classList.toggle('dark-theme');
-        
-        localStorage.setItem(THEME_STORAGE_KEY, isDark ? 'dark' : 'light');
-        
-        const themeToggle = document.querySelector('.theme-toggle');
-        if (themeToggle) {
-            updateThemeToggleIcon(themeToggle, isDark);
-        }
-        
-        // Add smooth transition
-        body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
-        setTimeout(() => {
-            body.style.transition = '';
-        }, 300);
+        var current = localStorage.getItem(THEME_STORAGE_KEY);
+        var idx = THEME_MODES.indexOf(current);
+        if (idx < 0) idx = 2;
+        var next = THEME_MODES[(idx + 1) % THEME_MODES.length];
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+        applyTheme(next);
     }
-    
-    function updateThemeToggleIcon(button, isDark) {
-        button.innerHTML = isDark 
-            ? '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/></svg>'
-            : '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>';
+
+    function updateThemeToggleIcon(button, mode) {
+        if (!button) return;
+        var icons = {
+            light: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/></svg>',
+            dark: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>',
+            auto: '<svg width="20" height="20" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a8 8 0 100 16 8 8 0 000-16zm0 2a6 6 0 010 12V4z"/></svg>'
+        };
+        var labels = { light: '浅色模式（点击切换到深色）', dark: '深色模式（点击切换到自动）', auto: '跟随系统（点击切换到浅色）' };
+        button.innerHTML = icons[mode] || icons.auto;
+        button.title = labels[mode] || labels.auto;
     }
 
     // ==========================================


### PR DESCRIPTION
## 变更内容

### 1. Navbar 全宽布局

移除 `.navbar-container` 的 `max-width: 1400px` 和 `margin: 0 auto`，让 navbar 撑满整个视口宽度。Logo 贴近视口左边缘，主题切换按钮贴近视口右边缘，与镜像站文档中心（Docusaurus）的 navbar 布局一致。

### 2. 主题切换三态模式

将主题切换从 2 态（浅色/深色）改为 3 态循环：

```
浅色 → 深色 → 跟随系统 → 浅色 → ...
```

- **默认模式**：「跟随系统」，读取 `prefers-color-scheme` 媒体查询
- **auto 模式**：监听系统主题变化，系统切换时实时跟随
- **三种图标**：☀️ 太阳（浅色）/ 🌙 月亮（深色）/ ◐ 半圆（跟随系统）
- **localStorage**：存储用户选择（`light` / `dark` / `auto`）
- **按钮 title**：显示当前模式及下一步切换提示

### 同步

`pages/mirror.css`、`pages/mirror.js` 与 `Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css`、`Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js` 两份副本同步修改。

## 验证

- Playwright 验证 navbar 位置（780px 视口）：`navWidth=780=viewportWidth`，`brandLeft=24`，`toggleRight=24` ✅
- Playwright 验证 navbar 位置（1920px 视口）：`navWidth=1920=viewportWidth`，`brandLeft=32`，`toggleRight=32` ✅
- Playwright 验证 3 态循环：auto（默认）→ light → dark → auto ✅
- Playwright 验证 localStorage 存储正确：`null` → `light` → `dark` → `auto` ✅
- Playwright 验证按钮 title 随模式切换更新 ✅
- `node --check` 语法验证通过 ✅
- 两份 CSS / JS 文件 diff 为空（完全同步）✅
