### PR TITLE
Add support for Composer and NuGet

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -293,7 +293,7 @@ html = HEADER
 odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
-cdn_mirror_list = ['pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora', 'rubygems']
+cdn_mirror_list = ['pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora', 'rubygems', 'composer', 'nuget']
 ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme', 'certs', 'git', 'scripts', 'ubuntu-cloud-images']
 
 for mirror in mirror_list:

--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -24,7 +24,7 @@ CDN_MIRROR_LIST = {
     'rubygems'
 }
 
-PROXY_MIRRORS = {'docker', 'maven', 'npm', 'go', 'crates.io-index'}
+PROXY_MIRRORS = {'docker', 'maven', 'npm', 'go', 'crates.io-index', 'composer', 'nuget'}
 
 IGNORE_DIR = {
     'static', 'font', 'help', 'Nginx-Fancyindex-Theme',


### PR DESCRIPTION
This pull request updates the list of supported mirrors in the codebase to include `composer` and `nuget`. These changes ensure that both scripts recognize and handle these additional mirrors as CDN and proxy mirrors.

**Mirror support updates:**

* Added `'composer'` and `'nuget'` to the `cdn_mirror_list` in `mirror_index.py`, enabling CDN handling for these mirrors.
* Added `'composer'` and `'nuget'` to the `PROXY_MIRRORS` set in `mirror_stats_json.py`, allowing proxy statistics to include these mirrors.