### PR TITLE
Add support for Composer and NuGet

### DIFF
--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -584,14 +584,27 @@ server {
     }
     # maven
     location /maven/ {
-        #rewrite ^/(.*) /nexus/#browse/browse:maven-public permanent;
-        rewrite ^/(.*) /nexus/service/rest/repository/browse/maven-public permanent;
+        #rewrite ^/(.*) /nexus/#browse/browse:maven permanent;
+        rewrite ^/(.*) /nexus/service/rest/repository/browse/maven permanent;
     }
     # npm
     location /npm/ {
         #rewrite ^/(.*) /nexus/#browse/browse:npm permanent;
-        rewrite ^/(.*) /nexus/rest/repository/browse/npm/ permanent;
+        rewrite ^/(.*) /nexus/service/rest/repository/browse/npm/ permanent;
     }
+
+    # nuget
+    location /nuget/ {
+        #rewrite ^/(.*) /nexus/#browse/browse:nuget permanent;
+        rewrite ^/(.*) /nexus/service/rest/repository/browse/nuget/ permanent;
+    }
+
+    # composer
+    location /composer/ {
+        #rewrite ^/(.*) /nexus/#browse/browse:composer permanent;
+        rewrite ^/(.*) /nexus/service/rest/repository/browse/composer/ permanent;
+    }
+    
     # go
     location /go/ {
         #rewrite ^/(.*) /nexus/#browse/browse:go permanent;


### PR DESCRIPTION
This pull request updates the `mirror.conf` Nginx configuration to improve repository browsing paths and add support for additional package repositories. The main changes include correcting the rewrite targets for existing repositories and introducing new locations for `nuget` and `composer`.

**Repository path corrections:**

* Updated the Maven rewrite rule to use `/nexus/service/rest/repository/browse/maven` instead of the previous path, ensuring consistency in repository browsing URLs.
* Updated the npm rewrite rule to use `/nexus/service/rest/repository/browse/npm/` for improved compatibility with Nexus repository browsing.

**Support for additional repositories:**

* Added a new location block for `nuget`, allowing requests to `/nuget/` to be rewritten to the appropriate Nexus browse path.
* Added a new location block for `composer`, enabling browsing of Composer packages via the correct Nexus endpoint.