### PR TITLE
修复手机端Island卡片加载后消失的问题

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -149,8 +149,8 @@
                 }
             });
         }, {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            threshold: 0,
+            rootMargin: '0px'
         });
         
         islands.forEach((island, index) => {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -149,8 +149,8 @@
                 }
             });
         }, {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            threshold: 0,
+            rootMargin: '0px'
         });
         
         islands.forEach((island, index) => {


### PR DESCRIPTION
## 问题

手机模式下，首页镜像列表卡片和状态页卡片都出现"加载了一半突然消失"的现象。

## 根因分析

`mirror.js` 的 `initIslandAnimations()` 使用 `IntersectionObserver` 控制 island 卡片的淡入动画，但配置过于严格：

```javascript
// 修复前
{ threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
```

- **`threshold: 0.1`**：要求元素 10% 可见才触发
- **`rootMargin: '0px 0px -50px 0px'`**：有效视口底部再缩减 50px

**首页**：镜像列表 island 高达 11800px，10% = 1180px。手机视口 812px，初始可见仅 ~358px（3%），observer 永远不触发。CSS `fadeIn` 动画播完后 JS 内联 `opacity:0` 接管，island 永久消失。

**状态页**：island 仅在视口边缘露出少量像素时，`rootMargin` 的 -50px 使有效视口更小，observer 无法触发。

时间线：
1. CSS `animation: fadeIn 0.6s` 播放 → island 短暂可见（opacity 0→1）
2. JS `initIslandAnimations()` 设置 `island.style.opacity = '0'`
3. CSS 动画结束后，内联 `opacity:0` 接管 → **island 消失**
4. `IntersectionObserver` 因 threshold/rootMargin 不满足，永远不触发 → **island 永久不可见**

## 修复

```javascript
// 修复后
{ threshold: 0, rootMargin: '0px' }
```

- `threshold: 0`：任何像素可见即触发
- `rootMargin: '0px'`：使用完整视口，不额外缩减

## 验证

在生产环境 `https://mirrors.gdut.edu.cn` 注入修复代码后测试（375×812 视口）：

**首页**：
- Island 0（11800px 主列表）：修复前 opacity=0，修复后 opacity=1 ✅
- 下方不可见 island：保持 opacity=0（滚动时触发）✅

**状态页**：
- Island 2（仅 32px 可见）：修复前 opacity=0，修复后 opacity=1 ✅
- 滚动后进入视口的 island：均变为 opacity=1 ✅

**语法检查**：`node --check` 两份 mirror.js 均通过 ✅
**同步检查**：两份 mirror.js diff 为空 ✅
