### PR TITLE
修复状态页composer/nuget显示为「从未同步」的问题

### DIFF
--- a/mirror_stats_json.py
+++ b/mirror_stats_json.py
@@ -21,7 +21,7 @@ CDN_MIRROR_LIST = {
     'pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis',
     'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports',
     'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora',
-    'rubygems'
+    'rubygems', 'composer', 'nuget'
 }
 
 PROXY_MIRRORS = {'docker', 'maven', 'npm', 'go', 'crates.io-index', 'composer', 'nuget'}


### PR DESCRIPTION
## 问题

composer 和 nuget 这两个基于 Nexus 的代理镜像，在状态页显示为「从未同步」，而非「缓存加速」。

## 根因

`mirror_stats_json.py`（状态页数据源）的 `CDN_MIRROR_LIST` 缺少 `composer` 和 `nuget`，而 `mirror_index.py`（首页）的 `cdn_mirror_list` 已包含它们。

两个文件的列表不同步：

| 镜像 | `mirror_index.py` 首页 | `mirror_stats_json.py` 状态页 |
|------|----------------------|------------------------------|
| composer | ✅ 在列表中 → "缓存加速" | ❌ 不在列表中 → `is_cache=False` |
| nuget | ✅ 在列表中 → "缓存加速" | ❌ 不在列表中 → `is_cache=False` |

状态判断流程（`get_sync_info`）：
- `is_cache=True` → 返回 `'cache'` → 前端显示「缓存加速」
- `is_cache=False` → 读取 `/home/mirror/sync_time/<name>` → 找不到文件 → 返回 `'never'` → 前端显示「从未同步」

composer/nuget 是 Nexus 代理镜像，没有 sync_time 文件，不在 `CDN_MIRROR_LIST` 时 `is_cache=False`，走入 `never` 分支。

## 修复

`CDN_MIRROR_LIST` 添加 `'composer'` 和 `'nuget'`，与 `mirror_index.py` 的 `cdn_mirror_list` 保持一致。

## 验证

- Python 语法检查通过 ✅
- AST 确认 `composer` 和 `nuget` 在 `CDN_MIRROR_LIST` 中 ✅

## 备注

部署后需在服务器上重新执行 `mirror_stats_json.py` 生成新的 `mirror_stats.json`，状态页才能刷新。
