### PR TITLE
首页镜像列表桌面端改为卡片形式 + hover聚焦放大动画

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -493,7 +493,7 @@ html.js .navbar-brand.autohide.is-visible {
 #distro-table {
     width: 100%;
     border-collapse: separate;
-    border-spacing: 0;
+    border-spacing: 0 6px;
 }
 
 #distro-table thead {
@@ -518,23 +518,40 @@ html.js .navbar-brand.autohide.is-visible {
     border-top-right-radius: var(--radius-md);
 }
 
-#distro-table td {
+#distro-table tbody td {
     padding: var(--spacing-md);
+    border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
+    background: var(--color-surface);
+    transition: background var(--transition-fast);
+}
+
+#distro-table tbody td:first-child {
+    border-left: 1px solid var(--color-border);
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+}
+
+#distro-table tbody td:last-child {
+    border-right: 1px solid var(--color-border);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
 }
 
 #distro-table tbody tr {
-    transition: all var(--transition-fast);
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: pointer;
 }
 
 #distro-table tbody tr:hover {
-    background: var(--color-hover);
+    transform: scale(1.02);
+    box-shadow: var(--shadow-md);
+    position: relative;
+    z-index: 1;
 }
 
-#distro-table tbody tr:last-child td {
-    border-bottom: none;
+#distro-table tbody tr:hover td {
+    background: var(--color-hover);
 }
 
 /* Status Badges */
@@ -895,13 +912,15 @@ p.answer {
         background: var(--color-surface);
     }
 
-    #distro-table td {
+    #distro-table tbody td {
         display: flex;
         justify-content: space-between;
         align-items: center;
         gap: var(--spacing-sm);
         padding: var(--spacing-xs) 0;
+        border: none;
         border-bottom: 1px solid var(--color-border);
+        border-radius: 0;
         white-space: normal;
     }
 
@@ -917,7 +936,7 @@ p.answer {
         flex-shrink: 0;
     }
 
-    #distro-table td:first-child {
+    #distro-table tbody td:first-child {
         font-size: 1rem;
         font-weight: 600;
         padding-bottom: var(--spacing-sm);

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -493,7 +493,7 @@ html.js .navbar-brand.autohide.is-visible {
 #distro-table {
     width: 100%;
     border-collapse: separate;
-    border-spacing: 0;
+    border-spacing: 0 6px;
 }
 
 #distro-table thead {
@@ -518,23 +518,40 @@ html.js .navbar-brand.autohide.is-visible {
     border-top-right-radius: var(--radius-md);
 }
 
-#distro-table td {
+#distro-table tbody td {
     padding: var(--spacing-md);
+    border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
+    background: var(--color-surface);
+    transition: background var(--transition-fast);
+}
+
+#distro-table tbody td:first-child {
+    border-left: 1px solid var(--color-border);
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+}
+
+#distro-table tbody td:last-child {
+    border-right: 1px solid var(--color-border);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
 }
 
 #distro-table tbody tr {
-    transition: all var(--transition-fast);
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: pointer;
 }
 
 #distro-table tbody tr:hover {
-    background: var(--color-hover);
+    transform: scale(1.02);
+    box-shadow: var(--shadow-md);
+    position: relative;
+    z-index: 1;
 }
 
-#distro-table tbody tr:last-child td {
-    border-bottom: none;
+#distro-table tbody tr:hover td {
+    background: var(--color-hover);
 }
 
 /* Status Badges */
@@ -895,13 +912,15 @@ p.answer {
         background: var(--color-surface);
     }
 
-    #distro-table td {
+    #distro-table tbody td {
         display: flex;
         justify-content: space-between;
         align-items: center;
         gap: var(--spacing-sm);
         padding: var(--spacing-xs) 0;
+        border: none;
         border-bottom: 1px solid var(--color-border);
+        border-radius: 0;
         white-space: normal;
     }
 
@@ -917,7 +936,7 @@ p.answer {
         flex-shrink: 0;
     }
 
-    #distro-table td:first-child {
+    #distro-table tbody td:first-child {
         font-size: 1rem;
         font-weight: 600;
         padding-bottom: var(--spacing-sm);


### PR DESCRIPTION
## 变更内容

将首页镜像列表桌面端从横线分隔表格改为卡片形式（保留表头行），并添加 hover 聚焦放大动画。

### 桌面端

- `border-spacing: 0 6px` — 行间 6px 间距，形成卡片分离感
- `tbody td` 从仅 `border-bottom` 改为 `border-top` + `border-bottom`，配合首尾单元格的 `border-left` / `border-right` 构成完整卡片边框
- `td:first-child` 左圆角 + `border-left`，`td:last-child` 右圆角 + `border-right`
- `tbody td` 添加 `background: var(--color-surface)` — 卡片实体背景
- **hover 聚焦放大**：`transform: scale(1.02)` + `box-shadow: var(--shadow-md)` + `position: relative` + `z-index: 1`
- hover 时 `td` 背景变为 `var(--color-hover)`

### 移动端（768px）

- 选择器从 `#distro-table td` 提升为 `#distro-table tbody td`（匹配桌面端特异性，确保重置生效）
- `td:first-child` / `td:last-child` 显式重置 `border` 和 `border-radius`
- 确保桌面端卡片样式不干扰移动端已有的卡片布局

## 验证

在生产环境 `https://mirrors.gdut.edu.cn` 注入修改后的 CSS 测试：

**桌面端（1400×900）**：
- `borderSpacing: "0px 6px"` ✅
- `td1BorderTop/Left/Bottom: "1px"` — 卡片边框 ✅
- `td1BorderRadius: "16px 0px 0px 16px"` — 左圆角 ✅
- `tdLastBorderRight: "1px"`, `tdLastBorderRadius: "0px 16px 16px 0px"` — 右圆角 ✅
- Hover：`transform: matrix(1.02, 0, 0, 1.02, 0, 0)` = `scale(1.02)` ✅
- Hover：`boxShadow: rgba(0, 0, 0, 0.06) 0px 4px 16px 0px` = `--shadow-md` ✅
- Hover：`position: relative`, `zIndex: 1` ✅
- Hover：`tdBackground: rgb(247, 250, 252)` = `--color-hover` ✅

**移动端（375×812）**：
- `td1Display: "flex"` — 移动端 flex 布局 ✅
- `td1BorderTop/Left/Right: "0px"` — 桌面端卡片边框已重置 ✅
- `td1BorderRadius: "0px"` — 桌面端圆角已重置 ✅
- `trBorder: "1px"`, `trBorderRadius: "16px"` — 移动端卡片边框正常 ✅
- `hasHorizontalScroll: false` — 无横向滚动 ✅
