### PR TITLE
修复镜像卡片hover直角矩形 + 恢复同步行紫色 + 添加卡片光晕效果

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -523,8 +523,9 @@ html.js .navbar-brand.autohide.is-visible {
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: var(--color-surface);
-    transition: background var(--transition-fast);
+    background: transparent;
+    position: relative;
+    z-index: 2;
 }
 
 #distro-table tbody td:first-child {
@@ -538,20 +539,55 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table tbody tr {
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
     cursor: pointer;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 卡片背景层 */
+#distro-table tbody tr::before {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    pointer-events: none;
+    z-index: 0;
+    transition: background var(--transition-fast);
+}
+
+/* 光晕 + 阴影层 */
+#distro-table tbody tr::after {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-md);
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    z-index: 1;
 }
 
 #distro-table tbody tr:hover {
     transform: scale(1.02);
-    box-shadow: var(--shadow-md);
-    position: relative;
     z-index: 1;
 }
 
-#distro-table tbody tr:hover td {
+#distro-table tbody tr:hover::before {
     background: var(--color-hover);
+}
+
+#distro-table tbody tr:hover::after {
+    opacity: 1;
+}
+
+/* Dark theme spotlight */
+.dark-theme #distro-table tbody tr::after {
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
 /* Status Badges */
@@ -589,8 +625,12 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-.syncing-row {
+.syncing-row::before {
     background: rgba(139, 92, 246, 0.05) !important;
+}
+
+.syncing-row:hover::before {
+    background: rgba(139, 92, 246, 0.08) !important;
 }
 
 @keyframes spin {
@@ -896,6 +936,11 @@ p.answer {
         width: 100%;
     }
 
+    #distro-table tbody tr::before,
+    #distro-table tbody tr::after {
+        display: none;
+    }
+
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -921,6 +966,8 @@ p.answer {
         border: none;
         border-bottom: 1px solid var(--color-border);
         border-radius: 0;
+        background: transparent;
+        z-index: auto;
         white-space: normal;
     }
 

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -270,7 +270,7 @@
 
     function initSpotlight() {
         function onMouseMove(e) {
-            const el = e.target.closest('.navbar, .island, #footer');
+            const el = e.target.closest('.navbar, .island, #footer, #distro-table tbody tr');
             if (!el) return;
             const rect = el.getBoundingClientRect();
             const x = (e.clientX - rect.left) / rect.width * 100;

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -523,8 +523,9 @@ html.js .navbar-brand.autohide.is-visible {
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: var(--color-surface);
-    transition: background var(--transition-fast);
+    background: transparent;
+    position: relative;
+    z-index: 2;
 }
 
 #distro-table tbody td:first-child {
@@ -538,20 +539,55 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table tbody tr {
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
     cursor: pointer;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 卡片背景层 */
+#distro-table tbody tr::before {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    pointer-events: none;
+    z-index: 0;
+    transition: background var(--transition-fast);
+}
+
+/* 光晕 + 阴影层 */
+#distro-table tbody tr::after {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-md);
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    z-index: 1;
 }
 
 #distro-table tbody tr:hover {
     transform: scale(1.02);
-    box-shadow: var(--shadow-md);
-    position: relative;
     z-index: 1;
 }
 
-#distro-table tbody tr:hover td {
+#distro-table tbody tr:hover::before {
     background: var(--color-hover);
+}
+
+#distro-table tbody tr:hover::after {
+    opacity: 1;
+}
+
+/* Dark theme spotlight */
+.dark-theme #distro-table tbody tr::after {
+    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
 /* Status Badges */
@@ -589,8 +625,12 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-.syncing-row {
+.syncing-row::before {
     background: rgba(139, 92, 246, 0.05) !important;
+}
+
+.syncing-row:hover::before {
+    background: rgba(139, 92, 246, 0.08) !important;
 }
 
 @keyframes spin {
@@ -896,6 +936,11 @@ p.answer {
         width: 100%;
     }
 
+    #distro-table tbody tr::before,
+    #distro-table tbody tr::after {
+        display: none;
+    }
+
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -921,6 +966,8 @@ p.answer {
         border: none;
         border-bottom: 1px solid var(--color-border);
         border-radius: 0;
+        background: transparent;
+        z-index: auto;
         white-space: normal;
     }
 

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -270,7 +270,7 @@
 
     function initSpotlight() {
         function onMouseMove(e) {
-            const el = e.target.closest('.navbar, .island, #footer');
+            const el = e.target.closest('.navbar, .island, #footer, #distro-table tbody tr');
             if (!el) return;
             const rect = el.getBoundingClientRect();
             const x = (e.clientX - rect.left) / rect.width * 100;


### PR DESCRIPTION
## 修复的三个问题

### 1. hover 时直角矩形残留

**原因**：`tr` 的 `box-shadow` 是直角矩形，在 `td` 圆角后面透出

**修复**：阴影从 `tr` 移到 `tr::after`（圆角伪元素），`tr` 不再设置 `box-shadow`

### 2. 同步中行紫色背景丢失

**原因**：`td` 设置了 `background: var(--color-surface)` 覆盖了 `.syncing-row` 的背景色

**修复**：
- `td` 改为 `background: transparent`，卡片背景由 `tr::before` 提供
- `.syncing-row::before` 设置紫色背景 `rgba(139, 92, 246, 0.05)`
- hover 时加深为 `rgba(139, 92, 246, 0.08)`

### 3. 卡片缺少鼠标光晕效果

**原因**：`initSpotlight()` 只监听 `.navbar, .island, #footer`，未包含 `tr`

**修复**：
- `mirror.js` 的 `closest()` 选择器添加 `#distro-table tbody tr`
- `tr::after` 提供 `radial-gradient` 光晕，hover 时 `opacity: 0→1`
- 深色主题光晕透明度 `0.08`（与 `.island` 一致）

## 实现方式（三层结构）

```
tr::before (z-index:0) → 卡片背景层（display:block 覆盖 table-cell 默认值）
tr::after  (z-index:1) → 光晕 + 阴影层（圆角矩形）
td         (z-index:2) → 透明背景，内容在最上层
```

## 移动端（768px）

- `tr::before` / `tr::after` 设 `display: none`
- `td` 重置 `z-index: auto`
- 移动端卡片布局不受影响

## Playwright 验证

**桌面端（1400×900）**：
- `trBoxShadow: "none"` — 无直角矩形 ✅
- `tdBackground: "rgba(0,0,0,0)"` — td 透明 ✅
- `::before display: "block"` — 背景层正常 ✅
- `::after display: "block"`, `zIndex: "1"` — 光晕层正常 ✅
- hover `trTransform: "matrix(1.02, 0, 0, 1.02, 0, 0)"` = scale(1.02) ✅
- hover `afterOpacity: "1"` — 光晕显示 ✅
- hover `beforeBackground: "rgb(247, 250, 252)"` = `--color-hover` ✅
- 光晕跟随：mouseX 49.96% → 31.95%, mouseY 49.71% → 65.71% ✅

**移动端（375×812）**：
- `beforeDisplay: "none"`, `afterDisplay: "none"` — 伪元素已禁用 ✅
- `tdZIndex: "auto"` — z-index 已重置 ✅
- `trBorder: "1px"`, `trBorderRadius: "16px"` — 移动端卡片正常 ✅
