### PR TITLE
修复镜像卡片列偏移：tr::before在table-row上创建匿名单元格

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -523,9 +523,10 @@ html.js .navbar-brand.autohide.is-visible {
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: transparent;
+    background: var(--color-surface);
     position: relative;
-    z-index: 2;
+    overflow: hidden;
+    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #distro-table tbody td:first-child {
@@ -539,54 +540,36 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table tbody tr {
-    position: relative;
     cursor: pointer;
     transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 卡片背景层 */
-#distro-table tbody tr::before {
-    content: '';
-    display: block;
-    position: absolute;
-    inset: 0;
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
-    pointer-events: none;
-    z-index: 0;
-    transition: background var(--transition-fast);
+#distro-table tbody tr:hover {
+    transform: scale(1.02);
+    position: relative;
+    z-index: 1;
 }
 
-/* 光晕 + 阴影层 */
-#distro-table tbody tr::after {
+#distro-table tbody tr:hover td {
+    background: var(--color-hover);
+    box-shadow: var(--shadow-md);
+}
+
+#distro-table tbody td::after {
     content: '';
-    display: block;
     position: absolute;
     inset: 0;
-    border-radius: var(--radius-md);
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
-    box-shadow: var(--shadow-md);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s;
-    z-index: 1;
 }
 
-#distro-table tbody tr:hover {
-    transform: scale(1.02);
-    z-index: 1;
-}
-
-#distro-table tbody tr:hover::before {
-    background: var(--color-hover);
-}
-
-#distro-table tbody tr:hover::after {
+#distro-table tbody tr:hover td::after {
     opacity: 1;
 }
 
-/* Dark theme spotlight */
-.dark-theme #distro-table tbody tr::after {
+.dark-theme #distro-table tbody td::after {
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
@@ -625,12 +608,12 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-.syncing-row::before {
-    background: rgba(139, 92, 246, 0.05) !important;
+#distro-table tbody tr.syncing-row td {
+    background: rgba(139, 92, 246, 0.05);
 }
 
-.syncing-row:hover::before {
-    background: rgba(139, 92, 246, 0.08) !important;
+#distro-table tbody tr.syncing-row:hover td {
+    background: rgba(139, 92, 246, 0.08);
 }
 
 @keyframes spin {
@@ -936,11 +919,6 @@ p.answer {
         width: 100%;
     }
 
-    #distro-table tbody tr::before,
-    #distro-table tbody tr::after {
-        display: none;
-    }
-
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -967,8 +945,13 @@ p.answer {
         border-bottom: 1px solid var(--color-border);
         border-radius: 0;
         background: transparent;
-        z-index: auto;
+        overflow: visible;
+        box-shadow: none;
         white-space: normal;
+    }
+
+    #distro-table tbody td::after {
+        display: none;
     }
 
     #distro-table tr:last-child td {

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -523,9 +523,10 @@ html.js .navbar-brand.autohide.is-visible {
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: transparent;
+    background: var(--color-surface);
     position: relative;
-    z-index: 2;
+    overflow: hidden;
+    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #distro-table tbody td:first-child {
@@ -539,54 +540,36 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table tbody tr {
-    position: relative;
     cursor: pointer;
     transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 卡片背景层 */
-#distro-table tbody tr::before {
-    content: '';
-    display: block;
-    position: absolute;
-    inset: 0;
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
-    pointer-events: none;
-    z-index: 0;
-    transition: background var(--transition-fast);
+#distro-table tbody tr:hover {
+    transform: scale(1.02);
+    position: relative;
+    z-index: 1;
 }
 
-/* 光晕 + 阴影层 */
-#distro-table tbody tr::after {
+#distro-table tbody tr:hover td {
+    background: var(--color-hover);
+    box-shadow: var(--shadow-md);
+}
+
+#distro-table tbody td::after {
     content: '';
-    display: block;
     position: absolute;
     inset: 0;
-    border-radius: var(--radius-md);
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
-    box-shadow: var(--shadow-md);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s;
-    z-index: 1;
 }
 
-#distro-table tbody tr:hover {
-    transform: scale(1.02);
-    z-index: 1;
-}
-
-#distro-table tbody tr:hover::before {
-    background: var(--color-hover);
-}
-
-#distro-table tbody tr:hover::after {
+#distro-table tbody tr:hover td::after {
     opacity: 1;
 }
 
-/* Dark theme spotlight */
-.dark-theme #distro-table tbody tr::after {
+.dark-theme #distro-table tbody td::after {
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
@@ -625,12 +608,12 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-.syncing-row::before {
-    background: rgba(139, 92, 246, 0.05) !important;
+#distro-table tbody tr.syncing-row td {
+    background: rgba(139, 92, 246, 0.05);
 }
 
-.syncing-row:hover::before {
-    background: rgba(139, 92, 246, 0.08) !important;
+#distro-table tbody tr.syncing-row:hover td {
+    background: rgba(139, 92, 246, 0.08);
 }
 
 @keyframes spin {
@@ -936,11 +919,6 @@ p.answer {
         width: 100%;
     }
 
-    #distro-table tbody tr::before,
-    #distro-table tbody tr::after {
-        display: none;
-    }
-
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -967,8 +945,13 @@ p.answer {
         border-bottom: 1px solid var(--color-border);
         border-radius: 0;
         background: transparent;
-        z-index: auto;
+        overflow: visible;
+        box-shadow: none;
         white-space: normal;
+    }
+
+    #distro-table tbody td::after {
+        display: none;
     }
 
     #distro-table tr:last-child td {


### PR DESCRIPTION
## 问题

镜像列表的卡片行相对标题行往左偏移了一整列。

## 根因

`tr::before { display: block }` 在 `display: table-row` 的 `tr` 上会创建**匿名表格单元格**，占据第一列位置，把真正的 `td` 推到右边。

测量数据（PR #125 部署后）：
```
th[0]: left=65, right=187  ← 标题行第一列
td[0]: left=187, right=310 ← 数据行第一列，偏移了122px（一列宽度）
```

## 修复

放弃 `tr::before`/`tr::after` 方案，回到 `td` 做所有视觉效果：

| 视觉效果 | 实现方式 |
|---------|---------|
| 卡片背景 | `td { background: var(--color-surface) }` |
| 卡片边框 | `td` border-top/bottom + `td:first-child` border-left + `td:last-child` border-right |
| 卡片圆角 | `td:first-child` 左圆角 + `td:last-child` 右圆角 |
| hover 放大 | `tr:hover { transform: scale(1.02) }` |
| hover 阴影 | `tr:hover td { box-shadow: var(--shadow-md) }`（在 td 上，因 td 有圆角） |
| hover 背景变色 | `tr:hover td { background: var(--color-hover) }` |
| 光晕 | `td::after { radial-gradient(...) }`，hover 时 `opacity: 0→1` |
| 同步紫色 | `tr.syncing-row td { background: rgba(139,92,246,0.05) }` |
| 光晕裁剪 | `td { overflow: hidden }` |

阴影在 `td` 上而非 `tr` 上 — 因 `td` 有圆角，`box-shadow` 在圆角处正确渲染。所有 `td` 都有 `box-shadow`，因 `border-spacing` 水平为 0，阴影连续无断裂。

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| th/td 对齐 | `th0Left=65, td0Left=65, aligned=true` ✅ |
| `tr::before` 消除 | `beforeDisplay: "none"` ✅ |
| hover scale(1.02) | `matrix(1.02, 0, 0, 1.02, 0, 0)` ✅ |
| hover td 背景变色 | `rgb(247, 250, 252)` = `--color-hover` ✅ |
| hover td 阴影 | `rgba(0,0,0,0.06) 0px 4px 16px 0px` = `--shadow-md` ✅ |
| 首尾 td 阴影一致 | 无直角矩形 ✅ |
| 光晕显示 | `afterOpacity: "1"` ✅ |
