### PR TITLE
修复光晕每列重复+列偏移：thead/tbody都用tr::before匿名单元格

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -518,6 +518,16 @@ html.js .navbar-brand.autohide.is-visible {
     border-top-right-radius: var(--radius-md);
 }
 
+/* 匿名单元格：thead 和 tbody 的 tr::before 各自创建一个，
+   使两者偏移一致；宽度 0 不影响布局 */
+#distro-table tr::before {
+    content: '';
+    display: block;
+    width: 0;
+    padding: 0;
+    border: none;
+}
+
 #distro-table tbody td {
     padding: var(--spacing-md);
     border-top: 1px solid var(--color-border);
@@ -525,8 +535,7 @@ html.js .navbar-brand.autohide.is-visible {
     color: var(--color-text-secondary);
     background: var(--color-surface);
     position: relative;
-    overflow: hidden;
-    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: background var(--transition-fast);
 }
 
 #distro-table tbody td:first-child {
@@ -555,21 +564,25 @@ html.js .navbar-brand.autohide.is-visible {
     box-shadow: var(--shadow-md);
 }
 
-#distro-table tbody td::after {
+/* 光晕层：整行一个，跟随鼠标位置 */
+#distro-table tbody tr::after {
     content: '';
+    display: block;
     position: absolute;
     inset: 0;
+    border-radius: var(--radius-md);
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s;
+    z-index: 1;
 }
 
-#distro-table tbody tr:hover td::after {
+#distro-table tbody tr:hover::after {
     opacity: 1;
 }
 
-.dark-theme #distro-table tbody td::after {
+.dark-theme #distro-table tbody tr::after {
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
@@ -919,6 +932,11 @@ p.answer {
         width: 100%;
     }
 
+    #distro-table tr::before,
+    #distro-table tbody tr::after {
+        display: none;
+    }
+
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -948,10 +966,6 @@ p.answer {
         overflow: visible;
         box-shadow: none;
         white-space: normal;
-    }
-
-    #distro-table tbody td::after {
-        display: none;
     }
 
     #distro-table tr:last-child td {

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -518,6 +518,16 @@ html.js .navbar-brand.autohide.is-visible {
     border-top-right-radius: var(--radius-md);
 }
 
+/* 匿名单元格：thead 和 tbody 的 tr::before 各自创建一个，
+   使两者偏移一致；宽度 0 不影响布局 */
+#distro-table tr::before {
+    content: '';
+    display: block;
+    width: 0;
+    padding: 0;
+    border: none;
+}
+
 #distro-table tbody td {
     padding: var(--spacing-md);
     border-top: 1px solid var(--color-border);
@@ -525,8 +535,7 @@ html.js .navbar-brand.autohide.is-visible {
     color: var(--color-text-secondary);
     background: var(--color-surface);
     position: relative;
-    overflow: hidden;
-    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: background var(--transition-fast);
 }
 
 #distro-table tbody td:first-child {
@@ -555,21 +564,25 @@ html.js .navbar-brand.autohide.is-visible {
     box-shadow: var(--shadow-md);
 }
 
-#distro-table tbody td::after {
+/* 光晕层：整行一个，跟随鼠标位置 */
+#distro-table tbody tr::after {
     content: '';
+    display: block;
     position: absolute;
     inset: 0;
+    border-radius: var(--radius-md);
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s;
+    z-index: 1;
 }
 
-#distro-table tbody tr:hover td::after {
+#distro-table tbody tr:hover::after {
     opacity: 1;
 }
 
-.dark-theme #distro-table tbody td::after {
+.dark-theme #distro-table tbody tr::after {
     background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
 }
 
@@ -919,6 +932,11 @@ p.answer {
         width: 100%;
     }
 
+    #distro-table tr::before,
+    #distro-table tbody tr::after {
+        display: none;
+    }
+
     #distro-table tr {
         margin-bottom: var(--spacing-sm);
         border: 1px solid var(--color-border);
@@ -948,10 +966,6 @@ p.answer {
         overflow: visible;
         box-shadow: none;
         white-space: normal;
-    }
-
-    #distro-table tbody td::after {
-        display: none;
     }
 
     #distro-table tr:last-child td {


### PR DESCRIPTION
## 修复的两个问题

### 1. 光晕每列都出现

**原因**：`td::after` 为每个 `td` 各生成一个光晕，鼠标在行内移动时每个 `td` 的光晕都以自己的中心计算位置

**修复**：光晕从 `td::after` 移回 `tr::after`，整行一个光晕

### 2. 列偏移（tr::before 创建匿名单元格）

**原因**：`tr::before { display: block }` 在 `table-row` 上创建匿名表格单元格，占据第一列位置

**修复**（用户提出的方案）：给 `thead` 的 `tr` 也加 `::before`，使 thead 和 tbody 偏移一致；匿名单元格宽度设为 0 不影响布局

## 最终结构

| 层 | 作用 |
|----|------|
| `tr::before` (thead+tbody) | 匿名单元格，`width: 0`，仅用于对齐 |
| `td` | `background` + `border` + `border-radius`（卡片视觉） |
| `td:hover` | `background → hover色` + `box-shadow → shadow-md` |
| `tr::after` | 整行光晕，hover 时 `opacity 0→1`，跟随鼠标位置 |
| `.syncing-row td` | 紫色背景 `rgba(139,92,246,0.05)` |

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| th/td 对齐 | `th0Left=65, td0Left=65, aligned=true` ✅ |
| thead `tr::before` | `display: block, width: 0px` ✅ |
| tbody `tr::before` | `display: block, width: 0px` ✅ |
| tbody `tr::after` | `display: block` ✅ |
| hover scale(1.02) | `matrix(1.02, 0, 0, 1.02, 0, 0)` ✅ |
| hover td 背景变色 | `rgb(247, 250, 252)` ✅ |
| hover td 阴影 | `rgba(0,0,0,0.06) 0px 4px 16px 0px` ✅ |
| 光晕在 `tr::after` 上 | `afterOpacity: 1` ✅ 整行一个 |
| 光晕跟随鼠标 | `mouseX: 50% → 27.38%` ✅ |
