### PR TITLE
修复光晕下每列边缘暗条：td透明无border，背景+边框+光晕统一到tr::after

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -530,60 +530,52 @@ html.js .navbar-brand.autohide.is-visible {
 
 #distro-table tbody td {
     padding: var(--spacing-md);
-    border-top: 1px solid var(--color-border);
-    border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: var(--color-surface);
+    background: transparent;
+    border: none;
     position: relative;
-    transition: background var(--transition-fast);
-}
-
-#distro-table tbody td:first-child {
-    border-left: 1px solid var(--color-border);
-    border-radius: var(--radius-md) 0 0 var(--radius-md);
-}
-
-#distro-table tbody td:last-child {
-    border-right: 1px solid var(--color-border);
-    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    z-index: 2;
 }
 
 #distro-table tbody tr {
+    position: relative;
     cursor: pointer;
     transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #distro-table tbody tr:hover {
     transform: scale(1.02);
-    position: relative;
     z-index: 1;
 }
 
-#distro-table tbody tr:hover td {
-    background: var(--color-hover);
-    box-shadow: var(--shadow-md);
-}
-
-/* 光晕层：整行一个，跟随鼠标位置 */
+/* 卡片背景 + 边框 + 光晕 + 阴影，整行一个伪元素，td 透明无暗条 */
 #distro-table tbody tr::after {
     content: '';
     display: block;
     position: absolute;
     inset: 0;
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
-    opacity: 0;
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
+        var(--color-surface);
+    box-shadow: none;
     pointer-events: none;
-    transition: opacity 0.2s;
-    z-index: 1;
+    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 0;
 }
 
 #distro-table tbody tr:hover::after {
-    opacity: 1;
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
+        var(--color-hover);
+    box-shadow: var(--shadow-md);
 }
 
-.dark-theme #distro-table tbody tr::after {
-    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
+.dark-theme #distro-table tbody tr:hover::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%),
+        var(--color-hover);
 }
 
 /* Status Badges */
@@ -621,12 +613,16 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-#distro-table tbody tr.syncing-row td {
-    background: rgba(139, 92, 246, 0.05);
+#distro-table tbody tr.syncing-row::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
+        rgba(139, 92, 246, 0.05);
 }
 
-#distro-table tbody tr.syncing-row:hover td {
-    background: rgba(139, 92, 246, 0.08);
+#distro-table tbody tr.syncing-row:hover::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
+        rgba(139, 92, 246, 0.08);
 }
 
 @keyframes spin {

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -530,60 +530,52 @@ html.js .navbar-brand.autohide.is-visible {
 
 #distro-table tbody td {
     padding: var(--spacing-md);
-    border-top: 1px solid var(--color-border);
-    border-bottom: 1px solid var(--color-border);
     color: var(--color-text-secondary);
-    background: var(--color-surface);
+    background: transparent;
+    border: none;
     position: relative;
-    transition: background var(--transition-fast);
-}
-
-#distro-table tbody td:first-child {
-    border-left: 1px solid var(--color-border);
-    border-radius: var(--radius-md) 0 0 var(--radius-md);
-}
-
-#distro-table tbody td:last-child {
-    border-right: 1px solid var(--color-border);
-    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    z-index: 2;
 }
 
 #distro-table tbody tr {
+    position: relative;
     cursor: pointer;
     transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #distro-table tbody tr:hover {
     transform: scale(1.02);
-    position: relative;
     z-index: 1;
 }
 
-#distro-table tbody tr:hover td {
-    background: var(--color-hover);
-    box-shadow: var(--shadow-md);
-}
-
-/* 光晕层：整行一个，跟随鼠标位置 */
+/* 卡片背景 + 边框 + 光晕 + 阴影，整行一个伪元素，td 透明无暗条 */
 #distro-table tbody tr::after {
     content: '';
     display: block;
     position: absolute;
     inset: 0;
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%);
-    opacity: 0;
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
+        var(--color-surface);
+    box-shadow: none;
     pointer-events: none;
-    transition: opacity 0.2s;
-    z-index: 1;
+    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 0;
 }
 
 #distro-table tbody tr:hover::after {
-    opacity: 1;
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
+        var(--color-hover);
+    box-shadow: var(--shadow-md);
 }
 
-.dark-theme #distro-table tbody tr::after {
-    background: radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%);
+.dark-theme #distro-table tbody tr:hover::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%),
+        var(--color-hover);
 }
 
 /* Status Badges */
@@ -621,12 +613,16 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 /* Row States */
-#distro-table tbody tr.syncing-row td {
-    background: rgba(139, 92, 246, 0.05);
+#distro-table tbody tr.syncing-row::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
+        rgba(139, 92, 246, 0.05);
 }
 
-#distro-table tbody tr.syncing-row:hover td {
-    background: rgba(139, 92, 246, 0.08);
+#distro-table tbody tr.syncing-row:hover::after {
+    background:
+        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
+        rgba(139, 92, 246, 0.08);
 }
 
 @keyframes spin {


### PR DESCRIPTION
## 问题

光晕照射下每列边缘出现暗条。之前错位版（PR #125）没有此问题，因为那时 `td` 没有 `border`。

## 原因

`td` 有 `border` (1px solid #e2e8f0) + `background` (#ffffff)，光晕叠加后 border 区域比 background 区域暗，形成暗条。

## 修复

将卡片背景、边框、圆角、光晕、阴影全部从 `td` 移到 `tr::after`：

| 层 | 修改前 | 修改后 |
|----|--------|--------|
| `td` | `background: #fff` + `border: 1px solid` | `background: transparent` + `border: none` + `z-index: 2` |
| `td:first-child` | `border-left` + `border-radius` | 删除 |
| `td:last-child` | `border-right` + `border-radius` | 删除 |
| `tr::after` | 仅光晕（opacity 切换） | 多层 background（光晕+卡片底色）+ border + border-radius |
| `tr:hover::after` | opacity 0→1 | 背景换 hover 色 + box-shadow |
| `.syncing-row td` | 紫色 background | 移到 `.syncing-row::after` |

`tr::after` 用 CSS 多层 `background` 同时承载光晕和卡片底色：
```css
background:
    radial-gradient(circle 200px at var(--mouse-x) var(--mouse-y), rgba(255,255,255,0.12), transparent 70%),
    var(--color-surface);
```

效果：整行一个连续的卡片表面，`td` 之间无 border 无间隙，光晕在统一表面上照射，不再有暗条。

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| `td` background | `rgba(0,0,0,0)` 透明 ✅ |
| `td` border | `0px` ✅ |
| `td` 间隙 | `gap=0` — 暗条物理消失 ✅ |
| `tr::after` border | `1px solid rgb(226,232,240)` ✅ |
| `tr::after` 背景 | 多层 radial-gradient + surface ✅ |
| th/td 对齐 | `th0Left=65, td0Left=65` ✅ |
| hover scale | `matrix(1.02,...)` ✅ |
| hover 阴影 | `rgba(0,0,0,0.06) 0px 4px 16px` ✅ |
| 光晕跟随鼠标 | `50% → 4.45%` ✅ |
