### PR TITLE
光晕效果改由 Island 卡片统一负责，表格行背景全透明

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -117,7 +117,7 @@ code {
     font-family: "Fira Code", Consolas, Menlo, Monaco, monospace;
     font-size: 0.875em;
     padding: 2px 6px;
-    background-color: var(--color-hover);
+    background-color: transparent;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
 }
@@ -497,7 +497,7 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table thead {
-    background: var(--color-hover);
+    background: transparent;
     border-radius: var(--radius-md);
 }
 
@@ -508,6 +508,7 @@ html.js .navbar-brand.autohide.is-visible {
     color: var(--color-text);
     border-bottom: 2px solid var(--color-border);
     white-space: nowrap;
+    background: transparent;
 }
 
 #distro-table th:first-child {
@@ -548,7 +549,7 @@ html.js .navbar-brand.autohide.is-visible {
     z-index: 1;
 }
 
-/* 卡片背景 + 边框 + 光晕 + 阴影，整行一个伪元素，td 透明无暗条 */
+/* 卡片边框 + 阴影，整行一个伪元素，背景透明让 Island 光晕透过 */
 #distro-table tbody tr::after {
     content: '';
     display: block;
@@ -556,26 +557,16 @@ html.js .navbar-brand.autohide.is-visible {
     inset: 0;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
-        var(--color-surface);
+    background: transparent;
     box-shadow: none;
     pointer-events: none;
-    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color var(--transition-fast);
     z-index: 0;
 }
 
 #distro-table tbody tr:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
-        var(--color-hover);
+    background: transparent;
     box-shadow: var(--shadow-md);
-}
-
-.dark-theme #distro-table tbody tr:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%),
-        var(--color-hover);
 }
 
 /* Status Badges */
@@ -614,15 +605,7 @@ html.js .navbar-brand.autohide.is-visible {
 
 /* Row States */
 #distro-table tbody tr.syncing-row::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
-        rgba(139, 92, 246, 0.05);
-}
-
-#distro-table tbody tr.syncing-row:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
-        rgba(139, 92, 246, 0.08);
+    background: rgba(139, 92, 246, 0.05);
 }
 
 @keyframes spin {
@@ -938,7 +921,7 @@ p.answer {
         border: 1px solid var(--color-border);
         border-radius: var(--radius-md);
         padding: var(--spacing-sm) var(--spacing-md);
-        background: var(--color-surface);
+        background: transparent;
     }
 
     #distro-table tr:last-child {
@@ -946,7 +929,7 @@ p.answer {
     }
 
     #distro-table tr:hover {
-        background: var(--color-surface);
+        background: transparent;
     }
 
     #distro-table tbody td {

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -270,7 +270,7 @@
 
     function initSpotlight() {
         function onMouseMove(e) {
-            const el = e.target.closest('.navbar, .island, #footer, #distro-table tbody tr');
+            const el = e.target.closest('.navbar, .island, #footer');
             if (!el) return;
             const rect = el.getBoundingClientRect();
             const x = (e.clientX - rect.left) / rect.width * 100;

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -117,7 +117,7 @@ code {
     font-family: "Fira Code", Consolas, Menlo, Monaco, monospace;
     font-size: 0.875em;
     padding: 2px 6px;
-    background-color: var(--color-hover);
+    background-color: transparent;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
 }
@@ -497,7 +497,7 @@ html.js .navbar-brand.autohide.is-visible {
 }
 
 #distro-table thead {
-    background: var(--color-hover);
+    background: transparent;
     border-radius: var(--radius-md);
 }
 
@@ -508,6 +508,7 @@ html.js .navbar-brand.autohide.is-visible {
     color: var(--color-text);
     border-bottom: 2px solid var(--color-border);
     white-space: nowrap;
+    background: transparent;
 }
 
 #distro-table th:first-child {
@@ -548,7 +549,7 @@ html.js .navbar-brand.autohide.is-visible {
     z-index: 1;
 }
 
-/* 卡片背景 + 边框 + 光晕 + 阴影，整行一个伪元素，td 透明无暗条 */
+/* 卡片边框 + 阴影，整行一个伪元素，背景透明让 Island 光晕透过 */
 #distro-table tbody tr::after {
     content: '';
     display: block;
@@ -556,26 +557,16 @@ html.js .navbar-brand.autohide.is-visible {
     inset: 0;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
-        var(--color-surface);
+    background: transparent;
     box-shadow: none;
     pointer-events: none;
-    transition: background var(--transition-fast), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color var(--transition-fast);
     z-index: 0;
 }
 
 #distro-table tbody tr:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
-        var(--color-hover);
+    background: transparent;
     box-shadow: var(--shadow-md);
-}
-
-.dark-theme #distro-table tbody tr:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.08), transparent 70%),
-        var(--color-hover);
 }
 
 /* Status Badges */
@@ -614,15 +605,7 @@ html.js .navbar-brand.autohide.is-visible {
 
 /* Row States */
 #distro-table tbody tr.syncing-row::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0), transparent 70%),
-        rgba(139, 92, 246, 0.05);
-}
-
-#distro-table tbody tr.syncing-row:hover::after {
-    background:
-        radial-gradient(circle 200px at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(255, 255, 255, 0.12), transparent 70%),
-        rgba(139, 92, 246, 0.08);
+    background: rgba(139, 92, 246, 0.05);
 }
 
 @keyframes spin {
@@ -938,7 +921,7 @@ p.answer {
         border: 1px solid var(--color-border);
         border-radius: var(--radius-md);
         padding: var(--spacing-sm) var(--spacing-md);
-        background: var(--color-surface);
+        background: transparent;
     }
 
     #distro-table tr:last-child {
@@ -946,7 +929,7 @@ p.answer {
     }
 
     #distro-table tr:hover {
-        background: var(--color-surface);
+        background: transparent;
     }
 
     #distro-table tbody td {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -270,7 +270,7 @@
 
     function initSpotlight() {
         function onMouseMove(e) {
-            const el = e.target.closest('.navbar, .island, #footer, #distro-table tbody tr');
+            const el = e.target.closest('.navbar, .island, #footer');
             if (!el) return;
             const rect = el.getBoundingClientRect();
             const x = (e.clientX - rect.left) / rect.width * 100;


### PR DESCRIPTION
## 问题

表格行自带光晕效果与 Island 卡片光晕叠加，视觉不协调。

## 修复

移除表格行光晕，让 Island 卡片光晕透过透明背景显示。

## 改动

### mirror.js
- `initSpotlight` 的 `closest` 移除 `#distro-table tbody tr`，鼠标在表格行上时 `--mouse-x/y` 设置到 Island 而非 tr

### mirror.css

| 元素 | 修改前 | 修改后 |
|------|--------|--------|
| `tr::after` | radial-gradient 光晕 + `var(--color-surface)` 底色 | `background: transparent`，只保留 border + border-radius |
| `tr:hover::after` | 光晕 + `var(--color-hover)` + box-shadow | `background: transparent` + box-shadow |
| `.dark-theme tr:hover::after` | 暗色光晕 | 删除（不再需要） |
| `.syncing-row::after` | 光晕 + 紫色底色 | 简化为 `rgba(139,92,246,0.05)` 紫色滤镜 |
| `.syncing-row:hover::after` | hover 光晕 + 紫色 | 删除（不再需要） |
| `thead` | `var(--color-hover)` | `transparent` |
| `th` | — | `transparent` |
| `code` | `var(--color-hover)` | `transparent` |
| 移动端 `tr` | `var(--color-surface)` | `transparent` |

## 效果

Island 卡片光晕在透明表格行上直接透过显示，同步行通过紫色滤镜（`rgba(139,92,246,0.05)`）标识。

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| `tr::after` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| `td` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| `thead` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| `th` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| `code` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| hover `tr` scale | `matrix(1.02,...)` ✅ |
| hover `tr::after` box-shadow | `rgba(0,0,0,0.06) 0px 4px 16px` ✅ |
| hover `tr::after` 背景 | `rgba(0,0,0,0)` 透明 ✅ |
| hover Island 光晕 | `opacity: 1` ✅ |
| 同步行紫色滤镜 | `rgba(139,92,246,0.05)` ✅ |
| 移动端 `tr` 透明 | `rgba(0,0,0,0)` ✅ |
| 移动端 `tr::after` | `display: none` ✅ |
