### PR TITLE
feat: 主站首页添加最新公告卡片

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -1042,6 +1042,69 @@ input::-moz-focus-inner {
 }
 
 /* ==========================================
+   News Feed (Sidebar Card)
+   ========================================== */
+
+.news-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.news-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.news-item:last-of-type {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.news-title {
+    color: var(--color-text);
+    font-weight: 500;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    transition: all var(--transition-fast);
+}
+
+.news-title:hover {
+    color: var(--color-primary);
+    padding-left: 4px;
+}
+
+.news-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+}
+
+.news-more {
+    display: block;
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--color-primary);
+    font-weight: 600;
+    margin-top: var(--spacing-xs);
+    transition: all var(--transition-fast);
+}
+
+.news-more:hover {
+    color: var(--color-primary-light);
+    padding-right: 4px;
+}
+
+.news-placeholder {
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    padding: var(--spacing-sm) 0;
+}
+
+/* ==========================================
    Print Styles
    ========================================== */
 

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -283,6 +283,139 @@
     }
 
     // ==========================================
+    // News Feed (RSS)
+    // ==========================================
+
+    function initNews() {
+        var RSS_URL = 'https://mirrors.gdut.edu.cn/help/news/rss.xml';
+        var CACHE_KEY = 'gdut-mirror-news-rss';
+        var CACHE_TTL = 30 * 60 * 1000;
+        var FETCH_TIMEOUT = 5000;
+        var NEWS_BASE_URL = 'https://mirrors.gdut.edu.cn/help/news/';
+        var MAX_ITEMS = 3;
+
+        var container = document.getElementById('news-content');
+        if (!container) return;
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function renderEmpty() {
+            container.innerHTML = '<p class="news-placeholder">暂无公告</p>';
+        }
+
+        function renderItems(items) {
+            if (!items || items.length === 0) {
+                renderEmpty();
+                return;
+            }
+            var html = '';
+            for (var i = 0; i < Math.min(items.length, MAX_ITEMS); i++) {
+                var item = items[i];
+                var dateStr = '';
+                if (item.date) {
+                    var d = new Date(item.date);
+                    if (!isNaN(d.getTime())) {
+                        var yr = d.getFullYear();
+                        var mo = String(d.getMonth() + 1).padStart(2, '0');
+                        var dy = String(d.getDate()).padStart(2, '0');
+                        dateStr = yr + '-' + mo + '-' + dy;
+                    }
+                }
+                html += '<div class="news-item">';
+                html += '<a href="' + item.link + '" target="_blank" rel="noopener" class="news-title">' + escapeHtml(item.title) + '</a>';
+                if (dateStr) {
+                    html += '<span class="news-date">' + dateStr + '</span>';
+                }
+                html += '</div>';
+            }
+            html += '<a href="' + NEWS_BASE_URL + '" target="_blank" rel="noopener" class="news-more">查看全部公告 →</a>';
+            container.innerHTML = html;
+        }
+
+        function getCachedData(freshOnly) {
+            try {
+                var cached = localStorage.getItem(CACHE_KEY);
+                if (!cached) return null;
+                var data = JSON.parse(cached);
+                if (freshOnly && Date.now() - data.timestamp > CACHE_TTL) return null;
+                return data.items;
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function setCachedData(items) {
+            try {
+                localStorage.setItem(CACHE_KEY, JSON.stringify({
+                    timestamp: Date.now(),
+                    items: items
+                }));
+            } catch (e) { /* ignore quota errors */ }
+        }
+
+        function parseRssXml(xmlText) {
+            var parser = new DOMParser();
+            var doc = parser.parseFromString(xmlText, 'text/xml');
+            if (doc.querySelector('parsererror')) return null;
+
+            var items = [];
+            var itemNodes = doc.querySelectorAll('item');
+            for (var i = 0; i < itemNodes.length; i++) {
+                var node = itemNodes[i];
+                var titleEl = node.querySelector('title');
+                var linkEl = node.querySelector('link');
+                var pubDateEl = node.querySelector('pubDate');
+
+                var title = titleEl ? titleEl.textContent.trim() : '';
+                var link = linkEl ? linkEl.textContent.trim() : '';
+                var date = pubDateEl ? pubDateEl.textContent.trim() : '';
+
+                if (title && link) {
+                    items.push({title: title, link: link, date: date});
+                }
+            }
+            return items;
+        }
+
+        var freshCache = getCachedData(true);
+        if (freshCache) {
+            renderItems(freshCache);
+            return;
+        }
+
+        var controller = new AbortController();
+        var timeoutId = setTimeout(function () {
+            controller.abort();
+        }, FETCH_TIMEOUT);
+
+        fetch(RSS_URL, {signal: controller.signal})
+            .then(function (response) {
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                return response.text();
+            })
+            .then(function (xmlText) {
+                clearTimeout(timeoutId);
+                var items = parseRssXml(xmlText);
+                if (items === null) throw new Error('RSS parse failed');
+                setCachedData(items);
+                renderItems(items);
+            })
+            .catch(function () {
+                clearTimeout(timeoutId);
+                var staleCache = getCachedData(false);
+                if (staleCache) {
+                    renderItems(staleCache);
+                } else {
+                    renderEmpty();
+                }
+            });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -294,6 +427,7 @@
         initSmoothScroll();
         initNavbarBrandVisibility();
         initSpotlight();
+        initNews();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -146,20 +146,17 @@ FOOTER = """
         </div>
         
         <aside class="bento-sidebar">
-            <div class="island island-compact">
+            <div class="island island-compact" id="news-island">
                 <div class="island-header">
                     <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                        <polyline points="7 10 12 15 17 10"></polyline>
-                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                        <path d="M3 11l18-5v12L3 14v-3z"></path>
+                        <path d="M11.6 16.8a3 3 0 11-5.8-1.6"></path>
                     </svg>
-                    <h2 class="island-title">快速下载</h2>
+                    <h2 class="island-title">最新公告</h2>
                 </div>
-                <ul>
-                    <li><a href="https://mirrors.gdut.edu.cn/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso">CentOS 9 安装盘</a></li>
-                    <li><a href="https://mirrors.gdut.edu.cn/debian-cd/current/amd64/iso-cd/debian-12.8.0-amd64-netinst.iso">Debian 12 网络安装盘</a></li>
-                    <li><a href="https://mirrors.gdut.edu.cn/ubuntu-releases/oracular/ubuntu-24.10-desktop-amd64.iso">Ubuntu 24.10 桌面版</a></li>
-                </ul>
+                <div id="news-content" class="news-content">
+                    <p class="news-placeholder">加载中...</p>
+                </div>
             </div>
             
             <div class="island island-compact">
@@ -175,6 +172,22 @@ FOOTER = """
                     <li><a href="https://mirrors.gdut.edu.cn">mirrors.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">自动选择</small></li>
                     <li><a href="https://mirrors4.gdut.edu.cn">mirrors4.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">IPv4 线路</small></li>
                     <li><a href="https://mirrors6.gdut.edu.cn">mirrors6.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">IPv6 线路</small></li>
+                </ul>
+            </div>
+            
+            <div class="island island-compact">
+                <div class="island-header">
+                    <svg class="island-icon" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="7 10 12 15 17 10"></polyline>
+                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                    </svg>
+                    <h2 class="island-title">快速下载</h2>
+                </div>
+                <ul>
+                    <li><a href="https://mirrors.gdut.edu.cn/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso">CentOS 9 安装盘</a></li>
+                    <li><a href="https://mirrors.gdut.edu.cn/debian-cd/current/amd64/iso-cd/debian-12.8.0-amd64-netinst.iso">Debian 12 网络安装盘</a></li>
+                    <li><a href="https://mirrors.gdut.edu.cn/ubuntu-releases/oracular/ubuntu-24.10-desktop-amd64.iso">Ubuntu 24.10 桌面版</a></li>
                 </ul>
             </div>
             

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -1042,6 +1042,69 @@ input::-moz-focus-inner {
 }
 
 /* ==========================================
+   News Feed (Sidebar Card)
+   ========================================== */
+
+.news-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.news-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.news-item:last-of-type {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.news-title {
+    color: var(--color-text);
+    font-weight: 500;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    transition: all var(--transition-fast);
+}
+
+.news-title:hover {
+    color: var(--color-primary);
+    padding-left: 4px;
+}
+
+.news-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+}
+
+.news-more {
+    display: block;
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--color-primary);
+    font-weight: 600;
+    margin-top: var(--spacing-xs);
+    transition: all var(--transition-fast);
+}
+
+.news-more:hover {
+    color: var(--color-primary-light);
+    padding-right: 4px;
+}
+
+.news-placeholder {
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    padding: var(--spacing-sm) 0;
+}
+
+/* ==========================================
    Print Styles
    ========================================== */
 

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -283,6 +283,139 @@
     }
 
     // ==========================================
+    // News Feed (RSS)
+    // ==========================================
+
+    function initNews() {
+        var RSS_URL = 'https://mirrors.gdut.edu.cn/help/news/rss.xml';
+        var CACHE_KEY = 'gdut-mirror-news-rss';
+        var CACHE_TTL = 30 * 60 * 1000;
+        var FETCH_TIMEOUT = 5000;
+        var NEWS_BASE_URL = 'https://mirrors.gdut.edu.cn/help/news/';
+        var MAX_ITEMS = 3;
+
+        var container = document.getElementById('news-content');
+        if (!container) return;
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function renderEmpty() {
+            container.innerHTML = '<p class="news-placeholder">暂无公告</p>';
+        }
+
+        function renderItems(items) {
+            if (!items || items.length === 0) {
+                renderEmpty();
+                return;
+            }
+            var html = '';
+            for (var i = 0; i < Math.min(items.length, MAX_ITEMS); i++) {
+                var item = items[i];
+                var dateStr = '';
+                if (item.date) {
+                    var d = new Date(item.date);
+                    if (!isNaN(d.getTime())) {
+                        var yr = d.getFullYear();
+                        var mo = String(d.getMonth() + 1).padStart(2, '0');
+                        var dy = String(d.getDate()).padStart(2, '0');
+                        dateStr = yr + '-' + mo + '-' + dy;
+                    }
+                }
+                html += '<div class="news-item">';
+                html += '<a href="' + item.link + '" target="_blank" rel="noopener" class="news-title">' + escapeHtml(item.title) + '</a>';
+                if (dateStr) {
+                    html += '<span class="news-date">' + dateStr + '</span>';
+                }
+                html += '</div>';
+            }
+            html += '<a href="' + NEWS_BASE_URL + '" target="_blank" rel="noopener" class="news-more">查看全部公告 →</a>';
+            container.innerHTML = html;
+        }
+
+        function getCachedData(freshOnly) {
+            try {
+                var cached = localStorage.getItem(CACHE_KEY);
+                if (!cached) return null;
+                var data = JSON.parse(cached);
+                if (freshOnly && Date.now() - data.timestamp > CACHE_TTL) return null;
+                return data.items;
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function setCachedData(items) {
+            try {
+                localStorage.setItem(CACHE_KEY, JSON.stringify({
+                    timestamp: Date.now(),
+                    items: items
+                }));
+            } catch (e) { /* ignore quota errors */ }
+        }
+
+        function parseRssXml(xmlText) {
+            var parser = new DOMParser();
+            var doc = parser.parseFromString(xmlText, 'text/xml');
+            if (doc.querySelector('parsererror')) return null;
+
+            var items = [];
+            var itemNodes = doc.querySelectorAll('item');
+            for (var i = 0; i < itemNodes.length; i++) {
+                var node = itemNodes[i];
+                var titleEl = node.querySelector('title');
+                var linkEl = node.querySelector('link');
+                var pubDateEl = node.querySelector('pubDate');
+
+                var title = titleEl ? titleEl.textContent.trim() : '';
+                var link = linkEl ? linkEl.textContent.trim() : '';
+                var date = pubDateEl ? pubDateEl.textContent.trim() : '';
+
+                if (title && link) {
+                    items.push({title: title, link: link, date: date});
+                }
+            }
+            return items;
+        }
+
+        var freshCache = getCachedData(true);
+        if (freshCache) {
+            renderItems(freshCache);
+            return;
+        }
+
+        var controller = new AbortController();
+        var timeoutId = setTimeout(function () {
+            controller.abort();
+        }, FETCH_TIMEOUT);
+
+        fetch(RSS_URL, {signal: controller.signal})
+            .then(function (response) {
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                return response.text();
+            })
+            .then(function (xmlText) {
+                clearTimeout(timeoutId);
+                var items = parseRssXml(xmlText);
+                if (items === null) throw new Error('RSS parse failed');
+                setCachedData(items);
+                renderItems(items);
+            })
+            .catch(function () {
+                clearTimeout(timeoutId);
+                var staleCache = getCachedData(false);
+                if (staleCache) {
+                    renderItems(staleCache);
+                } else {
+                    renderEmpty();
+                }
+            });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -294,6 +427,7 @@
         initSmoothScroll();
         initNavbarBrandVisibility();
         initSpotlight();
+        initNews();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();


### PR DESCRIPTION
## 改动内容

在主站首页右侧侧边栏新增「最新公告」卡片，展示文档站（mirrors-docs）的最新公告。

### 具体改动

- **mirror_index.py**: sidebar 新增「最新公告」island 卡片（放在最前），侧边栏顺序调整为：最新公告 → 域名选择 → 快速下载 → 联系我们 → 相关链接
- **pages/mirror.js**: 新增 `initNews()` 函数，客户端实时 fetch 文档站 RSS feed（`/help/news/rss.xml`），解析后渲染最近 3 条公告标题和日期；30 分钟 localStorage 缓存；5 秒超时；失败时降级显示「暂无公告」
- **pages/mirror.css**: 新增公告卡片相关样式（`.news-content`、`.news-item`、`.news-title`、`.news-date`、`.news-more`、`.news-placeholder`）
- **Nginx-Fancyindex-Theme/gdut-mirrors/**: 同步 `mirror.js` 和 `mirror.css` 副本（文件同步规则）

### 设计说明

- 文档站负责公告内容管理（Docusaurus Blog 插件），主站只做轻量的引用展示
- 公告标题和「查看全部公告」链接均在新标签页打开（`target="_blank"`）
- 日期格式为 `YYYY-MM-DD`，与镜像站现有「同步时间」风格一致

### 配套改动

文档站（mirrors-docs）已同步上线新闻公告功能：Blog 路由改为 `/news`，RSS feed 已启用。