### PR TITLE
Add Nexus Nginx configuration

### DIFF
--- a/nginx_conf/conf/repo.gdut.edu.cn.conf
+++ b/nginx_conf/conf/repo.gdut.edu.cn.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    server_name repo.gdut.edu.cn;  # 自行修改成你的域名
+    return 301 https://$server_name$request_uri;
+}
+server
+{
+    listen 443 ssl ;
+    server_name repo.gdut.edu.cn;
+    index index.php index.html index.htm default.php default.htm default.html;
+    root /home/nginx/wwwroot/repo.gdut.edu.cn;
+
+    #SSL-START SSL相关配置，请勿删除或修改下一行带注释的404规则
+    #error_page 404/404.html;
+    ssl_certificate /home/nginx/cert/-.gdut.edu.cn_chain.crt;
+    ssl_certificate_key /home/nginx/cert/-.gdut.edu.cn.key;
+    ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+CHACHA20:EECDH+CHACHA20-draft:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    add_header Strict-Transport-Security "max-age=31536000";
+    error_page 497  https://$host$request_uri;
+
+    #SSL-END
+
+    #ERROR-PAGE-START  错误页配置，可以注释、删除或修改
+    #error_page 404 /404.html;
+    #error_page 502 /502.html;
+    #ERROR-PAGE-END
+
+    client_max_body_size 0;
+    location / {
+        proxy_pass https://k8s-gateway-https;
+        #proxy_pass http://gdut-nexus-nexus3-hl.gdut-mirrors.svc.cluster.local:8081;
+        proxy_redirect default;
+        client_max_body_size 1000m;
+
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;      
+    }
+    
+    
+    access_log  /home/nginx/logs/repo.gdut.edu.cn.log extended;
+    error_log  /home/nginx/logs/repo.gdut.edu.cn.error.log;
+}


### PR DESCRIPTION
This pull request adds a new Nginx configuration file for the `repo.gdut.edu.cn` domain. The configuration sets up both HTTP and HTTPS servers, enforces HTTPS redirection, configures SSL settings, and establishes a reverse proxy to an upstream service.

**New Nginx server configuration for `repo.gdut.edu.cn`:**

* **HTTPS enforcement:** Adds an HTTP server block that redirects all traffic to HTTPS, ensuring secure connections.
* **SSL setup:** Configures SSL certificates, supported protocols, ciphers, and security headers for the HTTPS server block.
* **Reverse proxy:** Sets up a reverse proxy in the HTTPS server block to forward requests to the `k8s-gateway-https` upstream service, including necessary proxy headers.
* **Logging:** Specifies access and error log paths for monitoring.
* **Client request settings:** Adjusts `client_max_body_size` and includes commented-out error page configurations for potential customization.