### PR TITLE
Modify Nexus Nginx configuration

### DIFF
--- a/nginx_conf/conf/repo.gdut.edu.cn.conf
+++ b/nginx_conf/conf/repo.gdut.edu.cn.conf
@@ -36,6 +36,7 @@ server
         proxy_redirect default;
         client_max_body_size 1000m;
 
+        proxy_set_header HOST $host;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This pull request makes a minor configuration update to the Nginx server settings. The change adds a line to explicitly set the `HOST` header in proxied requests.

- Added `proxy_set_header HOST $host;` to the Nginx configuration to ensure the `HOST` header is forwarded correctly in proxied requests.