### PR TITLE
添加制品仓库(repo.gdut.edu.cn)链接至相关链接卡片和页脚

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -218,6 +218,7 @@ FOOTER = """
                     <li><a target="_blank" href="https://mirrors.gdut.edu.cn/help/">帮助文档</a></li>
                     <li><a target="_blank" href="status.html">当前状态</a></li>
                     <li><a target="_blank" rel="noopener noreferrer" href="https://registry.gdut.edu.cn">容器镜像库</a></li>
+                    <li><a target="_blank" rel="noopener noreferrer" href="https://repo.gdut.edu.cn">制品仓库</a></li>
                     <li><a target="_blank" href="https://speed.gdut.edu.cn">校内测速</a></li>
                 </ul>
             </div>
@@ -270,6 +271,14 @@ FOOTER = """
                 <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
             </svg>
             容器镜像库
+        </a>
+        &nbsp;|&nbsp;
+        <a target="_blank" rel="noopener noreferrer" href="https://repo.gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+                <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+            </svg>
+            制品仓库
         </a>
         &nbsp;|&nbsp;
         <a target="_blank" href="https://speed.gdut.edu.cn">

--- a/pages/about.html
+++ b/pages/about.html
@@ -129,6 +129,14 @@
             容器镜像库
         </a>
         &nbsp;|&nbsp;
+        <a target="_blank" rel="noopener noreferrer" href="https://repo.gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+                <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+            </svg>
+            制品仓库
+        </a>
+        &nbsp;|&nbsp;
         <a target="_blank" href="https://speed.gdut.edu.cn">
             <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>

--- a/pages/status.html
+++ b/pages/status.html
@@ -415,6 +415,14 @@
             容器镜像库
         </a>
         &nbsp;|&nbsp;
+        <a target="_blank" rel="noopener noreferrer" href="https://repo.gdut.edu.cn">
+            <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+                <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+            </svg>
+            制品仓库
+        </a>
+        &nbsp;|&nbsp;
         <a target="_blank" href="https://speed.gdut.edu.cn">
             <svg width="16" height="16" style="vertical-align: middle;" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>


### PR DESCRIPTION
## 背景

Nexus 制品仓库迁移至独立域名 `repo.gdut.edu.cn`，需要在页面相关链接中添加入口。

## 改动

| 文件 | 位置 | 改动 |
|------|------|------|
| `mirror_index.py` | 相关链接 island 卡片 | 在「容器镜像库」和「校内测速」之间添加「制品仓库」链接 |
| `mirror_index.py` | 页脚 footer | 同上位置添加，使用 archive-box 图标（Heroicons） |
| `pages/about.html` | 页脚 footer | 同上 |
| `pages/status.html` | 页脚 footer | 同上 |

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| about.html 页脚链接 | `容器镜像库 → 制品仓库 → 校内测速` ✅ |
| status.html 页脚链接 | `容器镜像库 → 制品仓库 → 校内测速` ✅ |
| 主页相关链接卡片 | `制品仓库` 已出现 ✅ |
| 主页页脚无溢出 | `scrollWidth=716 = clientWidth=716` ✅ |
