### PR TITLE
域名选择重做为滑块形式：显示当前域名 + IPv4/IPv6 支持检测

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -631,6 +631,121 @@ ul {
     margin: 0;
 }
 
+/* Domain Segment Slider */
+.seg-control {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    padding: 3px;
+    margin-bottom: var(--spacing-md);
+    background: var(--color-hover);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
+    transition: opacity var(--transition-fast);
+}
+
+.seg-thumb {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    left: 3px;
+    width: calc((100% - 6px) / 3);
+    background: var(--color-surface);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
+}
+
+.dark-theme .seg-thumb {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.seg-control[data-active="ipv4"] .seg-thumb {
+    transform: translateX(100%);
+}
+
+.seg-control[data-active="ipv6"] .seg-thumb {
+    transform: translateX(200%);
+}
+
+.seg-item {
+    position: relative;
+    z-index: 1;
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-xs) 0;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    border-radius: var(--radius-xl);
+    transition: color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.seg-item:hover {
+    color: var(--color-primary);
+}
+
+.seg-control[data-active="auto"] .seg-item[data-seg="auto"],
+.seg-control[data-active="ipv4"] .seg-item[data-seg="ipv4"],
+.seg-control[data-active="ipv6"] .seg-item[data-seg="ipv6"] {
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.seg-control.detecting {
+    opacity: 0.6;
+}
+
+.seg-item.seg-disabled {
+    opacity: 0.35;
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+.seg-item[data-unsupported] {
+    position: relative;
+}
+
+.seg-item[data-unsupported]::after {
+    content: attr(data-unsupported);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+    font-size: 0.75rem;
+    font-weight: 400;
+    white-space: nowrap;
+    color: var(--color-text-secondary);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s, visibility 0.2s;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.seg-item[data-unsupported]:hover::after {
+    opacity: 1;
+    visibility: visible;
+}
+
+.domain-list-disabled {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.domain-list-disabled .domain-note {
+    color: var(--color-error) !important;
+}
+
 .island ul {
     display: flex;
     flex-direction: column;

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -416,6 +416,66 @@
     }
 
     // ==========================================
+    // Domain Selector (域名滑块 + IPv4/IPv6 检测)
+    // ==========================================
+
+    var DOMAIN_PROBE_TIMEOUT = 6000;
+
+    function initDomainSelector() {
+        var slider = document.getElementById('domain-slider');
+        var list = document.getElementById('domain-list');
+        if (!slider || !list) return;
+
+        var host = window.location.hostname;
+        var activeSeg = host.indexOf('mirrors4') !== -1 ? 'ipv4'
+                      : host.indexOf('mirrors6') !== -1 ? 'ipv6'
+                      : 'auto';
+
+        slider.setAttribute('data-active', activeSeg);
+
+        slider.querySelectorAll('.seg-item').forEach(function (item) {
+            if (item.getAttribute('data-seg') === activeSeg) {
+                item.addEventListener('click', function (e) { e.preventDefault(); });
+            }
+        });
+
+        slider.classList.add('detecting');
+
+        var onIPv4 = activeSeg === 'ipv4';
+        var onIPv6 = activeSeg === 'ipv6';
+        var probes = [];
+
+        function probeProtocol(version) {
+            var hostBySeg = { ipv4: 'mirrors4.gdut.edu.cn', ipv6: 'mirrors6.gdut.edu.cn' };
+            var url = 'https://' + hostBySeg[version] + '/favicon.ico?r=' + Math.random();
+            var controller = new AbortController();
+            var timeoutId = setTimeout(function () { controller.abort(); }, DOMAIN_PROBE_TIMEOUT);
+            return fetch(url, { mode: 'no-cors', signal: controller.signal })
+                .then(function () { clearTimeout(timeoutId); return true; })
+                .catch(function () { clearTimeout(timeoutId); return false; });
+        }
+
+        function disableSeg(version) {
+            var seg = slider.querySelector('.seg-item[data-seg="' + version + '"]');
+            var li = list.querySelector('li[data-domain="' + version + '"]');
+            var note = list.querySelector('.domain-note[data-note="' + version + '"]');
+            if (seg) {
+                seg.classList.add('seg-disabled');
+                seg.setAttribute('data-unsupported', '当前网络不支持 ' + version.toUpperCase());
+            }
+            if (li) li.classList.add('domain-list-disabled');
+            if (note) note.textContent = '不支持 ' + version.toUpperCase();
+        }
+
+        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { if (!ok) disableSeg('ipv6'); }));
+        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { if (!ok) disableSeg('ipv4'); }));
+
+        Promise.all(probes).then(function () {
+            slider.classList.remove('detecting');
+        });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -428,6 +488,7 @@
         initNavbarBrandVisibility();
         initSpotlight();
         initNews();
+        initDomainSelector();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -168,10 +168,16 @@ FOOTER = """
                     </svg>
                     <h2 class="island-title">域名选择</h2>
                 </div>
-                <ul>
-                    <li><a href="https://mirrors.gdut.edu.cn">mirrors.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">自动选择</small></li>
-                    <li><a href="https://mirrors4.gdut.edu.cn">mirrors4.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">IPv4 线路</small></li>
-                    <li><a href="https://mirrors6.gdut.edu.cn">mirrors6.gdut.edu.cn</a> <small style="color: var(--color-text-muted);">IPv6 线路</small></li>
+                <div id="domain-slider" class="seg-control" role="tablist" aria-label="选择访问域名">
+                    <div id="domain-thumb" class="seg-thumb"></div>
+                    <a class="seg-item" role="tab" data-seg="auto" href="https://mirrors.gdut.edu.cn">自动</a>
+                    <a class="seg-item" role="tab" data-seg="ipv4" href="https://mirrors4.gdut.edu.cn">IPv4</a>
+                    <a class="seg-item" role="tab" data-seg="ipv6" href="https://mirrors6.gdut.edu.cn">IPv6</a>
+                </div>
+                <ul id="domain-list">
+                    <li data-domain="auto"><a href="https://mirrors.gdut.edu.cn">mirrors.gdut.edu.cn</a> <small class="domain-note" data-note="auto" style="color: var(--color-text-muted);">自动选择</small></li>
+                    <li data-domain="ipv4"><a href="https://mirrors4.gdut.edu.cn">mirrors4.gdut.edu.cn</a> <small class="domain-note" data-note="ipv4" style="color: var(--color-text-muted);">IPv4 线路</small></li>
+                    <li data-domain="ipv6"><a href="https://mirrors6.gdut.edu.cn">mirrors6.gdut.edu.cn</a> <small class="domain-note" data-note="ipv6" style="color: var(--color-text-muted);">IPv6 线路</small></li>
                 </ul>
             </div>
             

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -631,6 +631,121 @@ ul {
     margin: 0;
 }
 
+/* Domain Segment Slider */
+.seg-control {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    padding: 3px;
+    margin-bottom: var(--spacing-md);
+    background: var(--color-hover);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
+    transition: opacity var(--transition-fast);
+}
+
+.seg-thumb {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    left: 3px;
+    width: calc((100% - 6px) / 3);
+    background: var(--color-surface);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
+}
+
+.dark-theme .seg-thumb {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.seg-control[data-active="ipv4"] .seg-thumb {
+    transform: translateX(100%);
+}
+
+.seg-control[data-active="ipv6"] .seg-thumb {
+    transform: translateX(200%);
+}
+
+.seg-item {
+    position: relative;
+    z-index: 1;
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-xs) 0;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    border-radius: var(--radius-xl);
+    transition: color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.seg-item:hover {
+    color: var(--color-primary);
+}
+
+.seg-control[data-active="auto"] .seg-item[data-seg="auto"],
+.seg-control[data-active="ipv4"] .seg-item[data-seg="ipv4"],
+.seg-control[data-active="ipv6"] .seg-item[data-seg="ipv6"] {
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.seg-control.detecting {
+    opacity: 0.6;
+}
+
+.seg-item.seg-disabled {
+    opacity: 0.35;
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+.seg-item[data-unsupported] {
+    position: relative;
+}
+
+.seg-item[data-unsupported]::after {
+    content: attr(data-unsupported);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+    font-size: 0.75rem;
+    font-weight: 400;
+    white-space: nowrap;
+    color: var(--color-text-secondary);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s, visibility 0.2s;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.seg-item[data-unsupported]:hover::after {
+    opacity: 1;
+    visibility: visible;
+}
+
+.domain-list-disabled {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.domain-list-disabled .domain-note {
+    color: var(--color-error) !important;
+}
+
 .island ul {
     display: flex;
     flex-direction: column;

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -416,6 +416,66 @@
     }
 
     // ==========================================
+    // Domain Selector (域名滑块 + IPv4/IPv6 检测)
+    // ==========================================
+
+    var DOMAIN_PROBE_TIMEOUT = 6000;
+
+    function initDomainSelector() {
+        var slider = document.getElementById('domain-slider');
+        var list = document.getElementById('domain-list');
+        if (!slider || !list) return;
+
+        var host = window.location.hostname;
+        var activeSeg = host.indexOf('mirrors4') !== -1 ? 'ipv4'
+                      : host.indexOf('mirrors6') !== -1 ? 'ipv6'
+                      : 'auto';
+
+        slider.setAttribute('data-active', activeSeg);
+
+        slider.querySelectorAll('.seg-item').forEach(function (item) {
+            if (item.getAttribute('data-seg') === activeSeg) {
+                item.addEventListener('click', function (e) { e.preventDefault(); });
+            }
+        });
+
+        slider.classList.add('detecting');
+
+        var onIPv4 = activeSeg === 'ipv4';
+        var onIPv6 = activeSeg === 'ipv6';
+        var probes = [];
+
+        function probeProtocol(version) {
+            var hostBySeg = { ipv4: 'mirrors4.gdut.edu.cn', ipv6: 'mirrors6.gdut.edu.cn' };
+            var url = 'https://' + hostBySeg[version] + '/favicon.ico?r=' + Math.random();
+            var controller = new AbortController();
+            var timeoutId = setTimeout(function () { controller.abort(); }, DOMAIN_PROBE_TIMEOUT);
+            return fetch(url, { mode: 'no-cors', signal: controller.signal })
+                .then(function () { clearTimeout(timeoutId); return true; })
+                .catch(function () { clearTimeout(timeoutId); return false; });
+        }
+
+        function disableSeg(version) {
+            var seg = slider.querySelector('.seg-item[data-seg="' + version + '"]');
+            var li = list.querySelector('li[data-domain="' + version + '"]');
+            var note = list.querySelector('.domain-note[data-note="' + version + '"]');
+            if (seg) {
+                seg.classList.add('seg-disabled');
+                seg.setAttribute('data-unsupported', '当前网络不支持 ' + version.toUpperCase());
+            }
+            if (li) li.classList.add('domain-list-disabled');
+            if (note) note.textContent = '不支持 ' + version.toUpperCase();
+        }
+
+        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { if (!ok) disableSeg('ipv6'); }));
+        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { if (!ok) disableSeg('ipv4'); }));
+
+        Promise.all(probes).then(function () {
+            slider.classList.remove('detecting');
+        });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
     
@@ -428,6 +488,7 @@
         initNavbarBrandVisibility();
         initSpotlight();
         initNews();
+        initDomainSelector();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();


### PR DESCRIPTION
## 改动

参考学校测速网站（speed.gdut.edu.cn）的实现，将「域名选择」卡片从纯列表改为**滑块 + 列表**组合。位置不变，完整域名列表保留。

### 滑块（新增）
- 三段：`自动 | IPv4 | IPv6`，胶囊容器 + 绝对定位 thumb 平移，视觉语言复刻 navbar 主题切换
- `location.hostname` 判断当前访问域名 → thumb 滑到对应段 + 主题色高亮（`mirrors4`→IPv4，`mirrors6`→IPv6，其余→自动）
- 点击非当前段 = 跳转对应域名；点击当前段无操作

### IPv4/IPv6 支持检测（新增）
- `fetch('https://mirrors{4,6}.gdut.edu.cn/favicon.ico?r=xxx', {mode: 'no-cors'})` + 6s 超时
- 在 `mirrors` 上探测两个专属域名；在专属域名上只探测另一族；「自动」段永不灰掉
- 探测中滑块半透明（detecting 态），完成后恢复
- 明确 reject 才灰掉：滑块段 `opacity 0.35 + pointer-events:none` + hover tooltip「当前网络不支持 IPvX」；列表项灰掉 + 小字变红色「不支持 IPvX」
- 超时/异常按支持处理（避免误灰），不缓存结果

### 文件
| 文件 | 改动 |
|------|------|
| `mirror_index.py` | 域名选择卡片 HTML：滑块结构 + 增强 `<li>` |
| `pages/mirror.css` | `seg-control`/`seg-thumb`/`seg-item`/灰掉态/tooltip 样式 |
| `pages/mirror.js` | `initDomainSelector()`（判空保护，FancyIndex 页无此结构自动跳过） |
| FancyIndex 副本 ×2 | mirror.css / mirror.js 同步 |

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| 三段 thumb 精确对齐 + 主题色高亮 | ✅ auto/ipv4/ipv6 |
| 灰掉态 `opacity 0.35 + pointer-events:none + not-allowed` | ✅ |
| tooltip 内容「当前网络不支持 IPV6」 | ✅ |
| 列表灰掉 `opacity 0.45` + 红色小字 | ✅ |
| 探测完成移除 detecting | ✅（校园网双栈，无灰掉段） |
| 移动端 375px：三段等宽 95px，截图像素检查无溢出 | ✅ |
| 深色主题：thumb `rgba(255,255,255,0.1)` + 深色容器 | ✅ |
