### PR TITLE
修复域名滑块 hover 右移 + mirrors4/6 公告显示「暂无公告」

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -685,8 +685,10 @@ ul {
     transition: color var(--transition-fast), opacity var(--transition-fast);
 }
 
-.seg-item:hover {
+.seg-item:hover,
+.island a.seg-item:hover {
     color: var(--color-primary);
+    padding-left: 0;
 }
 
 .seg-control[data-active="auto"] .seg-item[data-seg="auto"],

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -287,11 +287,11 @@
     // ==========================================
 
     function initNews() {
-        var RSS_URL = 'https://mirrors.gdut.edu.cn/help/news/rss.xml';
+        var RSS_URL = '/help/news/rss.xml';
         var CACHE_KEY = 'gdut-mirror-news-rss';
         var CACHE_TTL = 30 * 60 * 1000;
         var FETCH_TIMEOUT = 5000;
-        var NEWS_BASE_URL = 'https://mirrors.gdut.edu.cn/help/news/';
+        var NEWS_BASE_URL = '/help/news/';
         var MAX_ITEMS = 3;
 
         var container = document.getElementById('news-content');

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -685,8 +685,10 @@ ul {
     transition: color var(--transition-fast), opacity var(--transition-fast);
 }
 
-.seg-item:hover {
+.seg-item:hover,
+.island a.seg-item:hover {
     color: var(--color-primary);
+    padding-left: 0;
 }
 
 .seg-control[data-active="auto"] .seg-item[data-seg="auto"],

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -287,11 +287,11 @@
     // ==========================================
 
     function initNews() {
-        var RSS_URL = 'https://mirrors.gdut.edu.cn/help/news/rss.xml';
+        var RSS_URL = '/help/news/rss.xml';
         var CACHE_KEY = 'gdut-mirror-news-rss';
         var CACHE_TTL = 30 * 60 * 1000;
         var FETCH_TIMEOUT = 5000;
-        var NEWS_BASE_URL = 'https://mirrors.gdut.edu.cn/help/news/';
+        var NEWS_BASE_URL = '/help/news/';
         var MAX_ITEMS = 3;
 
         var container = document.getElementById('news-content');


### PR DESCRIPTION
## 问题 1：滑块段文字 hover 右移

**原因**：`.island a:hover` 的 `padding-left: 4px` 作用于滑块段（它们是 `<a>`），specificity (0,2,1) 高于原 `.seg-item:hover` (0,2,0)，覆盖无效。

**修复**：新增 `.island a.seg-item:hover` (0,3,1) 规则，`padding-left` 显式归零。变红保留（符合预期），位移消除。

## 问题 2：mirrors4/6 公告显示「暂无公告」

**原因**：`RSS_URL` 硬编码 `https://mirrors.gdut.edu.cn/help/news/rss.xml`，在 mirrors4/6 上是跨域请求，Nginx 无 CORS 头被浏览器拦截，fetch 失败走 `renderEmpty()`。

**验证**：生产环境确认 `mirrors4.gdut.edu.cn/help/news/rss.xml` 存在（200，同一份文件），仅缺 CORS 头。

**修复**：`RSS_URL` / `NEWS_BASE_URL` 改为同源相对路径 `/help/news/rss.xml` / `/help/news/`——三个域名部署同一份文件，fetch 本域零跨域，「查看全部公告」链接自动跟随当前域名。

## Playwright 验证（生产环境 mirrors4 + mirrors6）

| 检查项 | 结果 |
|--------|------|
| mirrors4 公告显示（3 条 + 查看全部链接） | ✅ |
| mirrors6 公告显示 | ✅ |
| 滑块段 hover 位移 | `0px` ✅ |
| `padding-left` on hover | `0px` ✅ |
