### PR TITLE
域名列表支持状态改为圆角标签：绿色支持 / 红色不支持

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -739,13 +739,52 @@ ul {
     visibility: visible;
 }
 
+#domain-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#domain-list li {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-left: var(--spacing-md);
+    position: relative;
+}
+
+#domain-list li::before {
+    content: '→';
+    position: absolute;
+    left: 0;
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
+#domain-list .domain-badge {
+    margin-left: auto;
+    padding: 2px 10px;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+}
+
+#domain-list .domain-badge .status-icon {
+    width: 12px;
+    height: 12px;
+}
+
+.status-detecting {
+    background: rgba(100, 116, 139, 0.1);
+    color: var(--color-text-muted);
+}
+
 .domain-list-disabled {
     opacity: 0.45;
     pointer-events: none;
-}
-
-.domain-list-disabled .domain-note {
-    color: var(--color-error) !important;
 }
 
 .island ul {

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -457,18 +457,32 @@
 
         function disableSeg(version) {
             var seg = slider.querySelector('.seg-item[data-seg="' + version + '"]');
-            var li = list.querySelector('li[data-domain="' + version + '"]');
-            var note = list.querySelector('.domain-note[data-note="' + version + '"]');
             if (seg) {
                 seg.classList.add('seg-disabled');
                 seg.setAttribute('data-unsupported', '当前网络不支持 ' + version.toUpperCase());
             }
-            if (li) li.classList.add('domain-list-disabled');
-            if (note) note.textContent = '不支持 ' + version.toUpperCase();
         }
 
-        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { if (!ok) disableSeg('ipv6'); }));
-        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { if (!ok) disableSeg('ipv4'); }));
+        function setBadge(version, supported) {
+            var li = list.querySelector('li[data-domain="' + version + '"]');
+            if (!li) return;
+            var badge = li.querySelector('.domain-badge');
+            if (!badge) return;
+            var checkSvg = '<svg class="status-icon" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>';
+            var crossSvg = '<svg class="status-icon" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+            badge.classList.remove('status-detecting');
+            if (supported) {
+                badge.classList.add('status-success');
+                badge.innerHTML = checkSvg + '支持';
+            } else {
+                badge.classList.add('status-error');
+                badge.innerHTML = crossSvg + '不支持';
+                li.classList.add('domain-list-disabled');
+            }
+        }
+
+        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { setBadge('ipv6', ok); if (!ok) disableSeg('ipv6'); }));
+        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { setBadge('ipv4', ok); if (!ok) disableSeg('ipv4'); }));
 
         Promise.all(probes).then(function () {
             slider.classList.remove('detecting');

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -175,9 +175,9 @@ FOOTER = """
                     <a class="seg-item" role="tab" data-seg="ipv6" href="https://mirrors6.gdut.edu.cn">IPv6</a>
                 </div>
                 <ul id="domain-list">
-                    <li data-domain="auto"><a href="https://mirrors.gdut.edu.cn">mirrors.gdut.edu.cn</a> <small class="domain-note" data-note="auto" style="color: var(--color-text-muted);">自动选择</small></li>
-                    <li data-domain="ipv4"><a href="https://mirrors4.gdut.edu.cn">mirrors4.gdut.edu.cn</a> <small class="domain-note" data-note="ipv4" style="color: var(--color-text-muted);">IPv4 线路</small></li>
-                    <li data-domain="ipv6"><a href="https://mirrors6.gdut.edu.cn">mirrors6.gdut.edu.cn</a> <small class="domain-note" data-note="ipv6" style="color: var(--color-text-muted);">IPv6 线路</small></li>
+                    <li data-domain="auto"><a href="https://mirrors.gdut.edu.cn">mirrors.gdut.edu.cn</a> <small class="domain-note" style="color: var(--color-text-muted);">自动选择</small></li>
+                    <li data-domain="ipv4"><a href="https://mirrors4.gdut.edu.cn">mirrors4.gdut.edu.cn</a> <small class="domain-note" style="color: var(--color-text-muted);">IPv4 线路</small><span class="domain-badge status-badge status-detecting">检测中</span></li>
+                    <li data-domain="ipv6"><a href="https://mirrors6.gdut.edu.cn">mirrors6.gdut.edu.cn</a> <small class="domain-note" style="color: var(--color-text-muted);">IPv6 线路</small><span class="domain-badge status-badge status-detecting">检测中</span></li>
                 </ul>
             </div>
             

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -739,13 +739,52 @@ ul {
     visibility: visible;
 }
 
+#domain-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#domain-list li {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-left: var(--spacing-md);
+    position: relative;
+}
+
+#domain-list li::before {
+    content: '→';
+    position: absolute;
+    left: 0;
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
+#domain-list .domain-badge {
+    margin-left: auto;
+    padding: 2px 10px;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+}
+
+#domain-list .domain-badge .status-icon {
+    width: 12px;
+    height: 12px;
+}
+
+.status-detecting {
+    background: rgba(100, 116, 139, 0.1);
+    color: var(--color-text-muted);
+}
+
 .domain-list-disabled {
     opacity: 0.45;
     pointer-events: none;
-}
-
-.domain-list-disabled .domain-note {
-    color: var(--color-error) !important;
 }
 
 .island ul {

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -457,18 +457,32 @@
 
         function disableSeg(version) {
             var seg = slider.querySelector('.seg-item[data-seg="' + version + '"]');
-            var li = list.querySelector('li[data-domain="' + version + '"]');
-            var note = list.querySelector('.domain-note[data-note="' + version + '"]');
             if (seg) {
                 seg.classList.add('seg-disabled');
                 seg.setAttribute('data-unsupported', '当前网络不支持 ' + version.toUpperCase());
             }
-            if (li) li.classList.add('domain-list-disabled');
-            if (note) note.textContent = '不支持 ' + version.toUpperCase();
         }
 
-        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { if (!ok) disableSeg('ipv6'); }));
-        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { if (!ok) disableSeg('ipv4'); }));
+        function setBadge(version, supported) {
+            var li = list.querySelector('li[data-domain="' + version + '"]');
+            if (!li) return;
+            var badge = li.querySelector('.domain-badge');
+            if (!badge) return;
+            var checkSvg = '<svg class="status-icon" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>';
+            var crossSvg = '<svg class="status-icon" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+            badge.classList.remove('status-detecting');
+            if (supported) {
+                badge.classList.add('status-success');
+                badge.innerHTML = checkSvg + '支持';
+            } else {
+                badge.classList.add('status-error');
+                badge.innerHTML = crossSvg + '不支持';
+                li.classList.add('domain-list-disabled');
+            }
+        }
+
+        if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { setBadge('ipv6', ok); if (!ok) disableSeg('ipv6'); }));
+        if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { setBadge('ipv4', ok); if (!ok) disableSeg('ipv4'); }));
 
         Promise.all(probes).then(function () {
             slider.classList.remove('detecting');


### PR DESCRIPTION
## 改动

替换原「不支持 IPvX」红色小字方案：域名列表每行右侧增加圆角矩形标签，样式复用镜像列表的 `status-badge` 体系。

| 状态 | 样式 | 内容 |
|------|------|------|
| 检测中 | 灰底灰字胶囊 | `检测中` |
| 支持 | `status-success` 绿底绿字 | ✓ SVG + `支持` |
| 不支持 | `status-error` 红底红字 | ✗ SVG + `不支持`，整行灰掉不可点 |

「自动选择」行不参与检测，无标签。

### 文件
- `mirror_index.py`：ipv4/ipv6 行尾新增 `domain-badge` 标签（初始检测中态）
- `mirror.css`：`#domain-list` flex 布局 + 标签右对齐（`margin-left: auto`）+ 缩小版尺寸（0.75rem / padding 2px 10px / 12px 图标）+ `status-detecting` 灰态
- `mirror.js`：`setBadge()` 探测回调更新标签；`disableSeg` 移除旧红色小字逻辑

## Playwright 验证

| 检查项 | 结果 |
|--------|------|
| 支持态标签 | 绿底 `rgba(16,185,129,0.1)` + 绿字 + 胶囊 32px ✅ |
| 不支持态标签 | 红底 `rgba(239,68,68,0.1)` + 红字 + 行灰 `0.45` + 不可点 ✅ |
| 移动端 375px | 无溢出（293=293），标签右对齐 ✅ |
