### PR TITLE
快速下载重做：获取操作系统镜像 / 获取开源软件弹窗（两级导航 + 直链）

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -1261,6 +1261,331 @@ input::-moz-focus-inner {
 }
 
 /* ==========================================
+   Quick Download Entry & Download Modal
+   ========================================== */
+
+.quick-download-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.download-entry-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-entry-btn svg {
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.download-entry-btn:hover {
+    border-color: var(--color-primary);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.download-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-lg);
+}
+
+.download-modal[hidden] {
+    display: none;
+}
+
+.download-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+.download-modal-panel {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: min(680px, 100%);
+    max-height: min(80vh, 640px);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-xl);
+    animation: download-modal-in 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes download-modal-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.download-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-lg) var(--spacing-xl);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+}
+
+.download-modal-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.download-modal-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-modal-close:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+.download-modal-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.download-modal-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--spacing-md);
+    border-right: 1px solid var(--color-border);
+    overflow-y: auto;
+    flex-shrink: 0;
+    width: 168px;
+}
+
+.download-nav-item {
+    position: relative;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: 0.9375rem;
+    text-align: left;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-nav-item:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+.download-nav-item.active {
+    background: var(--color-hover);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.download-nav-item.active::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 20%;
+    bottom: 20%;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--color-primary);
+}
+
+.download-modal-content {
+    flex: 1;
+    padding: var(--spacing-md) var(--spacing-lg);
+    overflow-y: auto;
+    min-width: 0;
+}
+
+.download-variant-panel {
+    display: none;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.download-variant-panel.active {
+    display: flex;
+}
+
+.download-variant-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    transition: all var(--transition-fast);
+}
+
+.download-variant-row:hover {
+    border-color: var(--color-primary);
+    background: var(--color-hover);
+    box-shadow: var(--shadow-sm);
+}
+
+.download-variant-row[data-unavailable] {
+    opacity: 0.6;
+}
+
+.variant-info {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    min-width: 0;
+}
+
+.variant-label {
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.variant-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: var(--radius-xl);
+    background: rgba(100, 116, 139, 0.1);
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.variant-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.variant-size {
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.variant-unavailable {
+    color: var(--color-error);
+}
+
+.download-modal-footer {
+    padding: var(--spacing-md) var(--spacing-xl);
+    border-top: 1px solid var(--color-border);
+    flex-shrink: 0;
+}
+
+.download-modal-footer a {
+    color: var(--color-primary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: opacity var(--transition-fast);
+}
+
+.download-modal-footer a:hover {
+    opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+    .download-modal {
+        padding: var(--spacing-md);
+        align-items: flex-end;
+    }
+
+    .download-modal-panel {
+        width: 100%;
+        max-height: 85vh;
+        border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    }
+
+    .download-modal-body {
+        flex-direction: column;
+    }
+
+    .download-modal-nav {
+        flex-direction: row;
+        width: 100%;
+        overflow-x: auto;
+        overflow-y: hidden;
+        border-right: none;
+        border-bottom: 1px solid var(--color-border);
+        padding: var(--spacing-sm);
+        gap: var(--spacing-xs);
+        flex-shrink: 0;
+    }
+
+    .download-nav-item {
+        white-space: nowrap;
+        flex-shrink: 0;
+        padding: var(--spacing-xs) var(--spacing-md);
+    }
+
+    .download-nav-item.active::before {
+        left: 10%;
+        right: 10%;
+        top: auto;
+        bottom: 0;
+        width: auto;
+        height: 3px;
+    }
+
+    .download-modal-content {
+        padding: var(--spacing-md);
+    }
+
+    .download-variant-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-xs);
+    }
+
+    .variant-meta {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
+/* ==========================================
    Print Styles
    ========================================== */
 

--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -490,9 +490,90 @@
     }
 
     // ==========================================
+    // Download Modal (快速下载弹窗)
+    // ==========================================
+
+    function initDownloadModal() {
+        var modals = document.querySelectorAll('.download-modal');
+        if (modals.length === 0) return;
+
+        var openModal = null;
+
+        function focusablesIn(modal) {
+            return modal.querySelectorAll('button, a[href], [tabindex]:not([tabindex="-1"])');
+        }
+
+        function open(modal) {
+            if (openModal) close();
+            openModal = modal;
+            modal.hidden = false;
+            document.body.style.overflow = 'hidden';
+            var first = modal.querySelector('.download-modal-close');
+            if (first) first.focus();
+        }
+
+        function close() {
+            if (!openModal) return;
+            openModal.hidden = true;
+            openModal = null;
+            document.body.style.overflow = '';
+        }
+
+        modals.forEach(function (modal) {
+            modal.addEventListener('click', function (e) {
+                if (e.target.closest('[data-close]')) {
+                    close();
+                    return;
+                }
+                var navBtn = e.target.closest('.download-nav-item');
+                if (navBtn) {
+                    var targetId = navBtn.getAttribute('data-target');
+                    modal.querySelectorAll('.download-nav-item').forEach(function (b) {
+                        b.classList.toggle('active', b === navBtn);
+                    });
+                    modal.querySelectorAll('.download-variant-panel').forEach(function (p) {
+                        p.classList.toggle('active', p.getAttribute('data-panel') === targetId);
+                    });
+                }
+            });
+
+            modal.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape') {
+                    close();
+                    return;
+                }
+                if (e.key === 'Tab') {
+                    var focusables = Array.prototype.slice.call(focusablesIn(modal));
+                    if (focusables.length === 0) return;
+                    var first = focusables[0];
+                    var last = focusables[focusables.length - 1];
+                    if (e.shiftKey && document.activeElement === first) {
+                        e.preventDefault();
+                        last.focus();
+                    } else if (!e.shiftKey && document.activeElement === last) {
+                        e.preventDefault();
+                        first.focus();
+                    }
+                }
+            });
+        });
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && openModal) close();
+        });
+
+        document.querySelectorAll('.download-entry-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var modal = document.getElementById('download-modal-' + btn.getAttribute('data-modal'));
+                if (modal) open(modal);
+            });
+        });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
-    
+
     function init() {
         initTheme();
         initSearch();
@@ -503,6 +584,7 @@
         initSpotlight();
         initNews();
         initDomainSelector();
+        initDownloadModal();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();

--- a/download_items.py
+++ b/download_items.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+快速下载弹窗条目配置。
+
+字段说明:
+    name        左侧导航显示名
+    category    'os' 或 'software'
+    source      'disk'（全量镜像，扫 /mnt/mirror）或 'http'（缓存镜像，解析 Nginx 目录页）
+    base        目录基准（disk: /mnt/mirror 下的相对路径; http: URL 路径，host 由生成脚本拼接）
+    variants    变体列表，每项:
+        label   变体显示名
+        tag     架构/变体小标签
+        glob    文件名匹配模式（支持 * 通配符）
+        subdir  disk 源: 在 base 下的子目录（可含 {latest_dir} 占位符，取 sort -V 最新子目录）
+                http 源: URL 子路径（可含 {latest_dir}）
+"""
+
+OS_ITEMS = [
+    {
+        'name': 'Ubuntu',
+        'source': 'disk',
+        'base': 'ubuntu-releases',
+        'variants': [
+            {'label': '桌面版', 'tag': 'x86_64', 'subdir': '{latest_dir}', 'glob': '*-desktop-amd64.iso'},
+            {'label': '服务器版', 'tag': 'x86_64', 'subdir': '{latest_dir}', 'glob': '*-live-server-amd64.iso'},
+        ],
+    },
+    {
+        'name': 'Debian',
+        'source': 'disk',
+        'base': 'debian-cd/current/amd64',
+        'variants': [
+            {'label': '网络安装盘', 'tag': 'amd64', 'subdir': 'iso-cd', 'glob': 'debian-[0-9]*-netinst.iso'},
+            {'label': 'DVD 完整盘', 'tag': 'amd64', 'subdir': 'iso-dvd', 'glob': 'debian-[0-9]*-DVD-1.iso'},
+        ],
+    },
+    {
+        'name': 'CentOS Stream',
+        'source': 'http',
+        'base': 'centos-stream',
+        'variants': [
+            {'label': 'DVD 安装盘', 'tag': 'x86_64', 'subdir': '10-stream/BaseOS/x86_64/iso', 'glob': 'CentOS-Stream-*latest-x86_64-dvd1.iso'},
+            {'label': 'DVD 安装盘', 'tag': 'aarch64', 'subdir': '10-stream/BaseOS/aarch64/iso', 'glob': 'CentOS-Stream-*latest-aarch64-dvd1.iso'},
+        ],
+    },
+    {
+        'name': 'Kali Linux',
+        'source': 'disk',
+        'base': 'kali-images/current',
+        'variants': [
+            {'label': '安装盘', 'tag': 'amd64', 'subdir': '', 'glob': 'kali-*-installer-amd64.iso'},
+        ],
+    },
+    {
+        'name': 'FreeBSD',
+        'source': 'disk',
+        'base': 'freebsd/releases/ISO-IMAGES',
+        'variants': [
+            {'label': '安装盘', 'tag': 'amd64', 'subdir': '{latest_dir}', 'glob': '*-RELEASE-amd64-disc1.iso'},
+        ],
+    },
+    {
+        'name': 'Arch Linux',
+        'source': 'disk',
+        'base': 'archlinux/iso/latest',
+        'variants': [
+            {'label': '安装盘', 'tag': 'x86_64', 'subdir': '', 'glob': 'archlinux-x86_64.iso'},
+        ],
+    },
+    {
+        'name': 'Gentoo',
+        'source': 'disk',
+        'base': 'gentoo/releases/amd64/autobuilds/current-install-amd64-minimal',
+        'variants': [
+            {'label': '最小安装盘', 'tag': 'amd64', 'subdir': '', 'glob': 'install-amd64-minimal-*.iso'},
+        ],
+    },
+]
+
+SOFTWARE_ITEMS = [
+    {
+        'name': 'Docker CE',
+        'source': 'http',
+        'base': 'docker-ce',
+        'variants': [
+            {'label': 'Docker CLI', 'tag': 'macOS Intel', 'subdir': 'mac/static/stable/x86_64', 'glob': 'docker-*.tgz'},
+            {'label': 'Docker CLI', 'tag': 'macOS Apple Silicon', 'subdir': 'mac/static/stable/aarch64', 'glob': 'docker-*.tgz'},
+            {'label': 'Docker CLI', 'tag': 'Windows x64', 'subdir': 'win/static/stable/x86_64', 'glob': 'docker-*.zip'},
+        ],
+    },
+]

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -190,11 +190,26 @@ FOOTER = """
                     </svg>
                     <h2 class="island-title">快速下载</h2>
                 </div>
-                <ul>
-                    <li><a href="https://mirrors.gdut.edu.cn/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso">CentOS 9 安装盘</a></li>
-                    <li><a href="https://mirrors.gdut.edu.cn/debian-cd/current/amd64/iso-cd/debian-12.8.0-amd64-netinst.iso">Debian 12 网络安装盘</a></li>
-                    <li><a href="https://mirrors.gdut.edu.cn/ubuntu-releases/oracular/ubuntu-24.10-desktop-amd64.iso">Ubuntu 24.10 桌面版</a></li>
-                </ul>
+                <div class="quick-download-buttons">
+                    <button type="button" class="download-entry-btn" data-modal="os">
+                        <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <rect x="2" y="4" width="20" height="8" rx="2"></rect>
+                            <rect x="2" y="14" width="20" height="6" rx="2"></rect>
+                            <line x1="6" y1="8" x2="6.01" y2="8"></line>
+                            <line x1="6" y1="17" x2="6.01" y2="17"></line>
+                        </svg>
+                        <span>获取操作系统镜像</span>
+                    </button>
+                    <button type="button" class="download-entry-btn" data-modal="software">
+                        <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M16.5 9.4l-9-5.19"></path>
+                            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                            <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+                            <line x1="12" y1="22.08" x2="12" y2="12"></line>
+                        </svg>
+                        <span>获取开源软件</span>
+                    </button>
+                </div>
             </div>
             
             <div class="island island-compact">
@@ -304,6 +319,48 @@ FOOTER = """
 </html>
 """
 
+DOWNLOAD_MODAL_TEMPLATE = """
+<div id="download-modal-{modal_id}" class="download-modal" data-modal="{modal_id}" role="dialog" aria-modal="true" aria-label="{modal_title}" hidden>
+    <div class="download-modal-backdrop" data-close></div>
+    <div class="download-modal-panel">
+        <div class="download-modal-header">
+            <h3 class="download-modal-title">{modal_title}</h3>
+            <button type="button" class="download-modal-close" data-close aria-label="关闭">
+                <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+        </div>
+        <div class="download-modal-body">
+            <nav class="download-modal-nav">{nav_items}</nav>
+            <div class="download-modal-content">{variant_panels}</div>
+        </div>
+        {modal_footer}
+    </div>
+</div>
+"""
+
+DOWNLOAD_NAV_ITEM_TEMPLATE = """
+<button type="button" class="download-nav-item{active_class}" data-target="{modal_id}-{item_index}">{item_name}</button>
+"""
+
+DOWNLOAD_VARIANT_PANEL_TEMPLATE = """
+<div class="download-variant-panel{active_class}" data-panel="{modal_id}-{item_index}">
+    {variant_rows}
+</div>
+"""
+
+DOWNLOAD_VARIANT_ROW_TEMPLATE = """
+<a class="download-variant-row" href="{download_url}"{available}>
+    <div class="variant-info">
+        <span class="variant-label">{variant_label}</span>
+        <span class="variant-tag">{variant_tag}</span>
+    </div>
+    <div class="variant-meta">
+        {file_size_html}
+        <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+    </div>
+</a>
+"""
+
 # 读取下载次数统计
 download_stats = {}
 try:
@@ -372,6 +429,142 @@ for mirror in mirror_list:
                                             sync_status=sync_status, download_count=download_count)
 
 html += FOOTER
+
+
+# ==========================================
+# 快速下载弹窗生成（读取 download_items.py 配置）
+# ==========================================
+
+from download_items import OS_ITEMS, SOFTWARE_ITEMS
+
+try:
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    urlopen = None
+
+MIRROR_WEB_ROOT = 'https://mirrors.gdut.edu.cn'
+HTTP_DIR_TIMEOUT = 5
+
+
+def _match_glob(names, pattern):
+    import fnmatch
+    matched = fnmatch.filter(names, pattern)
+    return sorted(matched)[-1] if matched else None
+
+
+def _version_key(name):
+    import re
+    return [int(p) if p.isdigit() else p for p in re.split(r'[.-]', name)]
+
+
+def _latest_subdir(path):
+    try:
+        subdirs = [d for d in os.listdir(path)
+                   if os.path.isdir(os.path.join(path, d)) and d[0].isdigit()]
+        if not subdirs:
+            return None
+        return max(subdirs, key=_version_key)
+    except OSError:
+        return None
+
+
+def _scan_disk(item, variant):
+    base = os.path.join('/mnt/mirror', item['base'])
+    subdir = variant.get('subdir', '')
+    if '{latest_dir}' in subdir:
+        latest = _latest_subdir(base)
+        if not latest:
+            return None
+        subdir = subdir.replace('{latest_dir}', latest)
+    scan_dir = os.path.join(base, subdir) if subdir else base
+    try:
+        filename = _match_glob(os.listdir(scan_dir), variant['glob'])
+    except OSError:
+        return None
+    if not filename:
+        return None
+    filepath = os.path.join(scan_dir, filename)
+    try:
+        size = os.path.getsize(filepath)
+    except OSError:
+        size = None
+    rel_path = os.path.join(item['base'], subdir, filename) if subdir else os.path.join(item['base'], filename)
+    return {'url': MIRROR_WEB_ROOT + '/' + rel_path, 'size': size, 'browse': MIRROR_WEB_ROOT + '/' + item['base'] + '/'}
+
+
+def _parse_html_links(html_text):
+    import re
+    return re.findall(r'href="([^"]+)"', html_text)
+
+
+def _scan_http(item, variant):
+    if urlopen is None:
+        return None
+    subdir = variant.get('subdir', '')
+    url = MIRROR_WEB_ROOT + '/' + item['base'] + '/' + subdir + '/'
+    try:
+        resp = urlopen(url, timeout=HTTP_DIR_TIMEOUT)
+        links = _parse_html_links(resp.read().decode('utf-8', errors='replace'))
+    except (URLError, OSError):
+        return None
+    filenames = [l.rstrip('/') for l in links if '/' not in l.rstrip('/')]
+    filename = _match_glob(filenames, variant['glob'])
+    if not filename:
+        return None
+    size = None
+    try:
+        head_resp = urlopen(url + filename, timeout=HTTP_DIR_TIMEOUT)
+        size = int(head_resp.headers.get('Content-Length') or 0) or None
+    except (URLError, OSError, ValueError):
+        pass
+    return {'url': url + filename, 'size': size, 'browse': MIRROR_WEB_ROOT + '/' + item['base'] + '/'}
+
+
+def _format_size(size):
+    if size is None:
+        return '未知大小'
+    if size >= 1024 ** 3:
+        return '{:.2f} GB'.format(size / 1024 ** 3)
+    if size >= 1024 ** 2:
+        return '{:.1f} MB'.format(size / 1024 ** 2)
+    return '{:.1f} KB'.format(size / 1024)
+
+
+def _build_download_modal(modal_id, modal_title, items, footer_html=''):
+    nav_items_html = ''
+    variant_panels_html = ''
+    for idx, item in enumerate(items):
+        active_class = ' active' if idx == 0 else ''
+        nav_items_html += DOWNLOAD_NAV_ITEM_TEMPLATE.format(
+            active_class=active_class, modal_id=modal_id, item_index=idx, item_name=item['name'])
+        rows_html = ''
+        for variant in item['variants']:
+            scanner = _scan_disk if item['source'] == 'disk' else _scan_http
+            result = scanner(item, variant)
+            if result:
+                size_html = '<span class="variant-size">{}</span>'.format(_format_size(result['size']))
+                rows_html += DOWNLOAD_VARIANT_ROW_TEMPLATE.format(
+                    download_url=result['url'], available='', variant_label=variant['label'],
+                    variant_tag=variant['tag'], file_size_html=size_html)
+            else:
+                browse_url = MIRROR_WEB_ROOT + '/' + item['base'] + '/'
+                size_html = '<span class="variant-size variant-unavailable">暂不可用</span>'
+                rows_html += DOWNLOAD_VARIANT_ROW_TEMPLATE.format(
+                    download_url=browse_url, available=' data-unavailable',
+                    variant_label=variant['label'], variant_tag=variant['tag'], file_size_html=size_html)
+        variant_panels_html += DOWNLOAD_VARIANT_PANEL_TEMPLATE.format(
+            active_class=active_class, modal_id=modal_id, item_index=idx, variant_rows=rows_html)
+    return DOWNLOAD_MODAL_TEMPLATE.format(
+        modal_id=modal_id, modal_title=modal_title,
+        nav_items=nav_items_html, variant_panels=variant_panels_html, modal_footer=footer_html)
+
+
+os_modal_footer = ('<div class="download-modal-footer"><a href="' + MIRROR_WEB_ROOT + '/" target="_blank" rel="noopener noreferrer">'
+                   '浏览全部镜像目录 →</a></div>')
+
+html += _build_download_modal('os', '获取操作系统镜像', OS_ITEMS, os_modal_footer)
+html += _build_download_modal('software', '获取开源软件', SOFTWARE_ITEMS)
 
 with open('/mnt/mirror/index.html', 'w') as f:
     f.write(html)

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -1261,6 +1261,331 @@ input::-moz-focus-inner {
 }
 
 /* ==========================================
+   Quick Download Entry & Download Modal
+   ========================================== */
+
+.quick-download-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.download-entry-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-entry-btn svg {
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.download-entry-btn:hover {
+    border-color: var(--color-primary);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.download-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-lg);
+}
+
+.download-modal[hidden] {
+    display: none;
+}
+
+.download-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+.download-modal-panel {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: min(680px, 100%);
+    max-height: min(80vh, 640px);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-xl);
+    animation: download-modal-in 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes download-modal-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.download-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-lg) var(--spacing-xl);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+}
+
+.download-modal-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.download-modal-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-modal-close:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+.download-modal-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.download-modal-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--spacing-md);
+    border-right: 1px solid var(--color-border);
+    overflow-y: auto;
+    flex-shrink: 0;
+    width: 168px;
+}
+
+.download-nav-item {
+    position: relative;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: 0.9375rem;
+    text-align: left;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.download-nav-item:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+
+.download-nav-item.active {
+    background: var(--color-hover);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.download-nav-item.active::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 20%;
+    bottom: 20%;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--color-primary);
+}
+
+.download-modal-content {
+    flex: 1;
+    padding: var(--spacing-md) var(--spacing-lg);
+    overflow-y: auto;
+    min-width: 0;
+}
+
+.download-variant-panel {
+    display: none;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.download-variant-panel.active {
+    display: flex;
+}
+
+.download-variant-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    transition: all var(--transition-fast);
+}
+
+.download-variant-row:hover {
+    border-color: var(--color-primary);
+    background: var(--color-hover);
+    box-shadow: var(--shadow-sm);
+}
+
+.download-variant-row[data-unavailable] {
+    opacity: 0.6;
+}
+
+.variant-info {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    min-width: 0;
+}
+
+.variant-label {
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.variant-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: var(--radius-xl);
+    background: rgba(100, 116, 139, 0.1);
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.variant-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.variant-size {
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.variant-unavailable {
+    color: var(--color-error);
+}
+
+.download-modal-footer {
+    padding: var(--spacing-md) var(--spacing-xl);
+    border-top: 1px solid var(--color-border);
+    flex-shrink: 0;
+}
+
+.download-modal-footer a {
+    color: var(--color-primary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: opacity var(--transition-fast);
+}
+
+.download-modal-footer a:hover {
+    opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+    .download-modal {
+        padding: var(--spacing-md);
+        align-items: flex-end;
+    }
+
+    .download-modal-panel {
+        width: 100%;
+        max-height: 85vh;
+        border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    }
+
+    .download-modal-body {
+        flex-direction: column;
+    }
+
+    .download-modal-nav {
+        flex-direction: row;
+        width: 100%;
+        overflow-x: auto;
+        overflow-y: hidden;
+        border-right: none;
+        border-bottom: 1px solid var(--color-border);
+        padding: var(--spacing-sm);
+        gap: var(--spacing-xs);
+        flex-shrink: 0;
+    }
+
+    .download-nav-item {
+        white-space: nowrap;
+        flex-shrink: 0;
+        padding: var(--spacing-xs) var(--spacing-md);
+    }
+
+    .download-nav-item.active::before {
+        left: 10%;
+        right: 10%;
+        top: auto;
+        bottom: 0;
+        width: auto;
+        height: 3px;
+    }
+
+    .download-modal-content {
+        padding: var(--spacing-md);
+    }
+
+    .download-variant-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-xs);
+    }
+
+    .variant-meta {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
+/* ==========================================
    Print Styles
    ========================================== */
 

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -490,9 +490,90 @@
     }
 
     // ==========================================
+    // Download Modal (快速下载弹窗)
+    // ==========================================
+
+    function initDownloadModal() {
+        var modals = document.querySelectorAll('.download-modal');
+        if (modals.length === 0) return;
+
+        var openModal = null;
+
+        function focusablesIn(modal) {
+            return modal.querySelectorAll('button, a[href], [tabindex]:not([tabindex="-1"])');
+        }
+
+        function open(modal) {
+            if (openModal) close();
+            openModal = modal;
+            modal.hidden = false;
+            document.body.style.overflow = 'hidden';
+            var first = modal.querySelector('.download-modal-close');
+            if (first) first.focus();
+        }
+
+        function close() {
+            if (!openModal) return;
+            openModal.hidden = true;
+            openModal = null;
+            document.body.style.overflow = '';
+        }
+
+        modals.forEach(function (modal) {
+            modal.addEventListener('click', function (e) {
+                if (e.target.closest('[data-close]')) {
+                    close();
+                    return;
+                }
+                var navBtn = e.target.closest('.download-nav-item');
+                if (navBtn) {
+                    var targetId = navBtn.getAttribute('data-target');
+                    modal.querySelectorAll('.download-nav-item').forEach(function (b) {
+                        b.classList.toggle('active', b === navBtn);
+                    });
+                    modal.querySelectorAll('.download-variant-panel').forEach(function (p) {
+                        p.classList.toggle('active', p.getAttribute('data-panel') === targetId);
+                    });
+                }
+            });
+
+            modal.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape') {
+                    close();
+                    return;
+                }
+                if (e.key === 'Tab') {
+                    var focusables = Array.prototype.slice.call(focusablesIn(modal));
+                    if (focusables.length === 0) return;
+                    var first = focusables[0];
+                    var last = focusables[focusables.length - 1];
+                    if (e.shiftKey && document.activeElement === first) {
+                        e.preventDefault();
+                        last.focus();
+                    } else if (!e.shiftKey && document.activeElement === last) {
+                        e.preventDefault();
+                        first.focus();
+                    }
+                }
+            });
+        });
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && openModal) close();
+        });
+
+        document.querySelectorAll('.download-entry-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var modal = document.getElementById('download-modal-' + btn.getAttribute('data-modal'));
+                if (modal) open(modal);
+            });
+        });
+    }
+
+    // ==========================================
     // Initialize Everything
     // ==========================================
-    
+
     function init() {
         initTheme();
         initSearch();
@@ -503,6 +584,7 @@
         initSpotlight();
         initNews();
         initDomainSelector();
+        initDownloadModal();
 
         const yearSpan = document.getElementById('copyright-year');
         if (yearSpan) yearSpan.textContent = new Date().getFullYear();


### PR DESCRIPTION
## 改动

快速下载卡片从 3 个硬编码链接（版本早已过期）重做为两个按钮 + 弹窗：

- **获取操作系统镜像**：Ubuntu / Debian / CentOS Stream / Kali / FreeBSD / Arch / Gentoo（7 个发行版）
- **获取开源软件**：Docker CE（macOS Intel / Apple Silicon / Windows x64 三平台）

### 弹窗（两级导航）
- 左侧发行版列表（选中主题色高亮 + 左侧 3px 指示条），右侧变体行（名称 + 架构标签 + 文件大小 + 下载图标）
- OS 弹窗底部「浏览全部镜像目录 →」兜底
- Esc / 遮罩 / X 关闭，body 滚动锁定，Tab 焦点圈
- 移动端 <768px：bottom sheet + 顶部横向滚动 chips + 变体行堆叠

### 直链自动扫描（永不死链）
- **全量镜像**（Ubuntu/Debian/Kali/FreeBSD/Arch/Gentoo）：扫 `/mnt/mirror/`，版本目录 sort-V 语义取最新 + glob 匹配 + stat 取大小
- **缓存镜像**（CentOS Stream / Docker CE）：解析 Nginx 目录页（HTTP）提取文件列表 + HEAD 取 Content-Length（缓存镜像扫盘无效）
- `{latest_dir}` 占位符支持子目录版本探测
- 扫描失败降级：「暂不可用」红字 + 链接到镜像目录页

### 文件
| 文件 | 职责 |
|------|------|
| `download_items.py`（新增） | 声明式条目配置（name/base/variants/glob） |
| `mirror_index.py` | 扫描逻辑（disk/http 双源）+ 弹窗 HTML 生成 + 卡片两按钮 |
| `mirror.css` | 入口按钮 + modal + 两级导航 + 移动端降级样式 |
| `mirror.js` | `initDownloadModal()`（事件委托/Esc/焦点圈） |

## 验证

**扫描测试**（本地 Python 驱动）：13 条直链全部正确
- Ubuntu 26.04.1 desktop + live-server、Debian 13.6.0 netinst + DVD
- CentOS Stream 10 latest（x86_64 + aarch64，HTTP 解析）
- Kali 2026.2、FreeBSD 15.1、Arch latest 别名、Gentoo 最新
- Docker CE 29.8.0 三平台（tgz×2 + zip）
- 0 条「暂不可用」

**Playwright 验证**（生产环境注入）：
| 检查项 | 结果 |
|--------|------|
| 弹窗开合 / Esc / 遮罩点击关闭 | ✅ 滚动锁定与恢复正常 |
| 导航切换面板联动（Ubuntu→CentOS） | ✅ |
| 降级行（0.6 透明 + 红字 + 目录链接） | ✅ |
| 软件弹窗（Docker CE 三平台标签 + zip 直链） | ✅ |
| 移动端 375px：bottom sheet（贴底 16px padding）+ nav 横向滚动 + 行堆叠 | ✅ |
| 截图像素检查（四角遮罩暗色/面板亮色） | ✅ |
