### PR TITLE
下载弹窗增强：丰富架构变体 + 显示完整文件名 + 全面改用 HTTP 扫描

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -1470,24 +1470,22 @@ input::-moz-focus-inner {
 
 .variant-info {
     display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
+    flex-direction: column;
+    gap: 2px;
     min-width: 0;
 }
 
 .variant-label {
+    font-family: "Fira Code", Consolas, Menlo, Monaco, monospace;
+    font-size: 0.875rem;
     font-weight: 500;
-    white-space: nowrap;
+    color: var(--color-text);
+    overflow-wrap: anywhere;
 }
 
-.variant-tag {
-    display: inline-flex;
-    align-items: center;
-    padding: 2px 8px;
-    border-radius: var(--radius-xl);
-    background: rgba(100, 116, 139, 0.1);
-    color: var(--color-text-muted);
+.variant-note {
     font-size: 0.75rem;
+    color: var(--color-text-muted);
     white-space: nowrap;
 }
 

--- a/download_items.py
+++ b/download_items.py
@@ -1,78 +1,75 @@
 # -*- coding: utf-8 -*-
 """
-快速下载弹窗条目配置。
+快速下载弹窗条目配置（全部通过 HTTP 解析 Nginx 目录页获取文件列表，
+因为部分架构由缓存加速提供，磁盘扫描不完整）。
 
 字段说明:
     name        左侧导航显示名
-    category    'os' 或 'software'
-    source      'disk'（全量镜像，扫 /mnt/mirror）或 'http'（缓存镜像，解析 Nginx 目录页）
-    base        目录基准（disk: /mnt/mirror 下的相对路径; http: URL 路径，host 由生成脚本拼接）
+    base        镜像根路径（URL 相对路径）
     variants    变体列表，每项:
-        label   变体显示名
-        tag     架构/变体小标签
-        glob    文件名匹配模式（支持 * 通配符）
-        subdir  disk 源: 在 base 下的子目录（可含 {latest_dir} 占位符，取 sort -V 最新子目录）
-                http 源: URL 子路径（可含 {latest_dir}）
+        note    变体说明（副文本，如「桌面版 · x86_64」）
+        subdir  URL 子路径，支持 {latest_dir} 占位符（版本号数字开头的子目录按版本排序取最新）
+        glob    文件名匹配模式
 """
 
 OS_ITEMS = [
     {
         'name': 'Ubuntu',
-        'source': 'disk',
         'base': 'ubuntu-releases',
         'variants': [
-            {'label': '桌面版', 'tag': 'x86_64', 'subdir': '{latest_dir}', 'glob': '*-desktop-amd64.iso'},
-            {'label': '服务器版', 'tag': 'x86_64', 'subdir': '{latest_dir}', 'glob': '*-live-server-amd64.iso'},
+            {'note': '桌面版 · x86_64', 'subdir': '{latest_dir}', 'glob': '*-desktop-amd64.iso'},
+            {'note': '服务器版 · x86_64', 'subdir': '{latest_dir}', 'glob': '*-live-server-amd64.iso'},
         ],
     },
     {
         'name': 'Debian',
-        'source': 'disk',
-        'base': 'debian-cd/current/amd64',
+        'base': 'debian-cd',
         'variants': [
-            {'label': '网络安装盘', 'tag': 'amd64', 'subdir': 'iso-cd', 'glob': 'debian-[0-9]*-netinst.iso'},
-            {'label': 'DVD 完整盘', 'tag': 'amd64', 'subdir': 'iso-dvd', 'glob': 'debian-[0-9]*-DVD-1.iso'},
+            {'note': '网络安装 · amd64', 'subdir': 'current/amd64/iso-cd', 'glob': 'debian-[0-9]*-netinst.iso'},
+            {'note': 'DVD 完整安装 · amd64', 'subdir': 'current/amd64/iso-dvd', 'glob': 'debian-[0-9]*-DVD-1.iso'},
+            {'note': 'Live GNOME · amd64', 'subdir': 'current-live/amd64/iso-hybrid', 'glob': 'debian-live-*-gnome.iso'},
+            {'note': 'Live KDE · amd64', 'subdir': 'current-live/amd64/iso-hybrid', 'glob': 'debian-live-*-kde.iso'},
+            {'note': 'Live XFCE · amd64', 'subdir': 'current-live/amd64/iso-hybrid', 'glob': 'debian-live-*-xfce.iso'},
+            {'note': 'Live Cinnamon · amd64', 'subdir': 'current-live/amd64/iso-hybrid', 'glob': 'debian-live-*-cinnamon.iso'},
         ],
     },
     {
         'name': 'CentOS Stream',
-        'source': 'http',
         'base': 'centos-stream',
         'variants': [
-            {'label': 'DVD 安装盘', 'tag': 'x86_64', 'subdir': '10-stream/BaseOS/x86_64/iso', 'glob': 'CentOS-Stream-*latest-x86_64-dvd1.iso'},
-            {'label': 'DVD 安装盘', 'tag': 'aarch64', 'subdir': '10-stream/BaseOS/aarch64/iso', 'glob': 'CentOS-Stream-*latest-aarch64-dvd1.iso'},
+            {'note': 'DVD 安装盘 · x86_64', 'subdir': '10-stream/BaseOS/x86_64/iso', 'glob': 'CentOS-Stream-*latest-x86_64-dvd1.iso'},
+            {'note': 'DVD 安装盘 · aarch64', 'subdir': '10-stream/BaseOS/aarch64/iso', 'glob': 'CentOS-Stream-*latest-aarch64-dvd1.iso'},
         ],
     },
     {
         'name': 'Kali Linux',
-        'source': 'disk',
         'base': 'kali-images/current',
         'variants': [
-            {'label': '安装盘', 'tag': 'amd64', 'subdir': '', 'glob': 'kali-*-installer-amd64.iso'},
+            {'note': '完整安装盘 · amd64', 'subdir': '', 'glob': 'kali-*-installer-amd64.iso'},
+            {'note': '网络安装 · amd64', 'subdir': '', 'glob': 'kali-*-installer-netinst-amd64.iso'},
         ],
     },
     {
         'name': 'FreeBSD',
-        'source': 'disk',
         'base': 'freebsd/releases/ISO-IMAGES',
         'variants': [
-            {'label': '安装盘', 'tag': 'amd64', 'subdir': '{latest_dir}', 'glob': '*-RELEASE-amd64-disc1.iso'},
+            {'note': '安装盘 disc1 · amd64', 'subdir': '{latest_dir}', 'glob': '*-RELEASE-amd64-disc1.iso'},
+            {'note': 'DVD dvd1 · amd64', 'subdir': '{latest_dir}', 'glob': '*-RELEASE-amd64-dvd1.iso'},
+            {'note': '引导盘 bootonly · amd64', 'subdir': '{latest_dir}', 'glob': '*-RELEASE-amd64-bootonly.iso'},
         ],
     },
     {
         'name': 'Arch Linux',
-        'source': 'disk',
         'base': 'archlinux/iso/latest',
         'variants': [
-            {'label': '安装盘', 'tag': 'x86_64', 'subdir': '', 'glob': 'archlinux-x86_64.iso'},
+            {'note': '安装盘 · x86_64', 'subdir': '', 'glob': 'archlinux-x86_64.iso'},
         ],
     },
     {
         'name': 'Gentoo',
-        'source': 'disk',
         'base': 'gentoo/releases/amd64/autobuilds/current-install-amd64-minimal',
         'variants': [
-            {'label': '最小安装盘', 'tag': 'amd64', 'subdir': '', 'glob': 'install-amd64-minimal-*.iso'},
+            {'note': '最小安装盘 · amd64', 'subdir': '', 'glob': 'install-amd64-minimal-*.iso'},
         ],
     },
 ]
@@ -80,12 +77,11 @@ OS_ITEMS = [
 SOFTWARE_ITEMS = [
     {
         'name': 'Docker CE',
-        'source': 'http',
         'base': 'docker-ce',
         'variants': [
-            {'label': 'Docker CLI', 'tag': 'macOS Intel', 'subdir': 'mac/static/stable/x86_64', 'glob': 'docker-*.tgz'},
-            {'label': 'Docker CLI', 'tag': 'macOS Apple Silicon', 'subdir': 'mac/static/stable/aarch64', 'glob': 'docker-*.tgz'},
-            {'label': 'Docker CLI', 'tag': 'Windows x64', 'subdir': 'win/static/stable/x86_64', 'glob': 'docker-*.zip'},
+            {'note': 'macOS Intel', 'subdir': 'mac/static/stable/x86_64', 'glob': 'docker-*.tgz'},
+            {'note': 'macOS Apple Silicon', 'subdir': 'mac/static/stable/aarch64', 'glob': 'docker-*.tgz'},
+            {'note': 'Windows x64', 'subdir': 'win/static/stable/x86_64', 'glob': 'docker-*.zip'},
         ],
     },
 ]

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -351,8 +351,8 @@ DOWNLOAD_VARIANT_PANEL_TEMPLATE = """
 DOWNLOAD_VARIANT_ROW_TEMPLATE = """
 <a class="download-variant-row" href="{download_url}"{available}>
     <div class="variant-info">
-        <span class="variant-label">{variant_label}</span>
-        <span class="variant-tag">{variant_tag}</span>
+        <span class="variant-label">{filename}</span>
+        <span class="variant-note">{variant_note}</span>
     </div>
     <div class="variant-meta">
         {file_size_html}
@@ -458,55 +458,37 @@ def _version_key(name):
     return [int(p) if p.isdigit() else p for p in re.split(r'[.-]', name)]
 
 
-def _latest_subdir(path):
-    try:
-        subdirs = [d for d in os.listdir(path)
-                   if os.path.isdir(os.path.join(path, d)) and d[0].isdigit()]
-        if not subdirs:
-            return None
-        return max(subdirs, key=_version_key)
-    except OSError:
-        return None
-
-
-def _scan_disk(item, variant):
-    base = os.path.join('/mnt/mirror', item['base'])
-    subdir = variant.get('subdir', '')
-    if '{latest_dir}' in subdir:
-        latest = _latest_subdir(base)
-        if not latest:
-            return None
-        subdir = subdir.replace('{latest_dir}', latest)
-    scan_dir = os.path.join(base, subdir) if subdir else base
-    try:
-        filename = _match_glob(os.listdir(scan_dir), variant['glob'])
-    except OSError:
-        return None
-    if not filename:
-        return None
-    filepath = os.path.join(scan_dir, filename)
-    try:
-        size = os.path.getsize(filepath)
-    except OSError:
-        size = None
-    rel_path = os.path.join(item['base'], subdir, filename) if subdir else os.path.join(item['base'], filename)
-    return {'url': MIRROR_WEB_ROOT + '/' + rel_path, 'size': size, 'browse': MIRROR_WEB_ROOT + '/' + item['base'] + '/'}
-
-
 def _parse_html_links(html_text):
     import re
     return re.findall(r'href="([^"]+)"', html_text)
 
 
+def _fetch_dir_links(url):
+    try:
+        resp = urlopen(url, timeout=HTTP_DIR_TIMEOUT)
+        return _parse_html_links(resp.read().decode('utf-8', errors='replace'))
+    except (URLError, OSError):
+        return None
+
+
 def _scan_http(item, variant):
     if urlopen is None:
         return None
+    base_url = MIRROR_WEB_ROOT + '/' + item['base'] + '/'
     subdir = variant.get('subdir', '')
-    url = MIRROR_WEB_ROOT + '/' + item['base'] + '/' + subdir + '/'
-    try:
-        resp = urlopen(url, timeout=HTTP_DIR_TIMEOUT)
-        links = _parse_html_links(resp.read().decode('utf-8', errors='replace'))
-    except (URLError, OSError):
+    if '{latest_dir}' in subdir:
+        links = _fetch_dir_links(base_url)
+        if links is None:
+            return None
+        version_dirs = sorted({l.rstrip('/') for l in links
+                               if l.rstrip('/').startswith(('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))})
+        if not version_dirs:
+            return None
+        latest_dir = max(version_dirs, key=_version_key)
+        subdir = subdir.replace('{latest_dir}', latest_dir)
+    url = base_url + subdir + '/' if subdir else base_url
+    links = _fetch_dir_links(url)
+    if links is None:
         return None
     filenames = [l.rstrip('/') for l in links if '/' not in l.rstrip('/')]
     filename = _match_glob(filenames, variant['glob'])
@@ -518,7 +500,7 @@ def _scan_http(item, variant):
         size = int(head_resp.headers.get('Content-Length') or 0) or None
     except (URLError, OSError, ValueError):
         pass
-    return {'url': url + filename, 'size': size, 'browse': MIRROR_WEB_ROOT + '/' + item['base'] + '/'}
+    return {'url': url + filename, 'size': size, 'filename': filename, 'browse': base_url}
 
 
 def _format_size(size):
@@ -540,19 +522,18 @@ def _build_download_modal(modal_id, modal_title, items, footer_html=''):
             active_class=active_class, modal_id=modal_id, item_index=idx, item_name=item['name'])
         rows_html = ''
         for variant in item['variants']:
-            scanner = _scan_disk if item['source'] == 'disk' else _scan_http
-            result = scanner(item, variant)
+            result = _scan_http(item, variant)
             if result:
                 size_html = '<span class="variant-size">{}</span>'.format(_format_size(result['size']))
                 rows_html += DOWNLOAD_VARIANT_ROW_TEMPLATE.format(
-                    download_url=result['url'], available='', variant_label=variant['label'],
-                    variant_tag=variant['tag'], file_size_html=size_html)
+                    download_url=result['url'], available='', filename=result['filename'],
+                    variant_note=variant['note'], file_size_html=size_html)
             else:
                 browse_url = MIRROR_WEB_ROOT + '/' + item['base'] + '/'
                 size_html = '<span class="variant-size variant-unavailable">暂不可用</span>'
                 rows_html += DOWNLOAD_VARIANT_ROW_TEMPLATE.format(
                     download_url=browse_url, available=' data-unavailable',
-                    variant_label=variant['label'], variant_tag=variant['tag'], file_size_html=size_html)
+                    filename=variant['glob'], variant_note=variant['note'], file_size_html=size_html)
         variant_panels_html += DOWNLOAD_VARIANT_PANEL_TEMPLATE.format(
             active_class=active_class, modal_id=modal_id, item_index=idx, variant_rows=rows_html)
     return DOWNLOAD_MODAL_TEMPLATE.format(

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -1470,24 +1470,22 @@ input::-moz-focus-inner {
 
 .variant-info {
     display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
+    flex-direction: column;
+    gap: 2px;
     min-width: 0;
 }
 
 .variant-label {
+    font-family: "Fira Code", Consolas, Menlo, Monaco, monospace;
+    font-size: 0.875rem;
     font-weight: 500;
-    white-space: nowrap;
+    color: var(--color-text);
+    overflow-wrap: anywhere;
 }
 
-.variant-tag {
-    display: inline-flex;
-    align-items: center;
-    padding: 2px 8px;
-    border-radius: var(--radius-xl);
-    background: rgba(100, 116, 139, 0.1);
-    color: var(--color-text-muted);
+.variant-note {
     font-size: 0.75rem;
+    color: var(--color-text-muted);
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## 三点改进

### 1. 变体大幅扩充（10 → 20 条）

| 发行版 | 变体 |
|--------|------|
| Ubuntu | desktop / live-server（26.04.1） |
| Debian | netinst / DVD-1 + **Live GNOME / KDE / XFCE / Cinnamon**（current-live） |
| CentOS Stream | x86_64 / **aarch64** dvd1 |
| Kali | installer / **installer-netinst** |
| FreeBSD | disc1 / **dvd1 / bootonly** |
| Arch / Gentoo | 不变 |
| Docker CE | 三平台（不变） |

### 2. 显示完整文件名（参考 USTC）

- 变体行主文本 = 完整镜像文件名，等宽字体（Fira Code）：`debian-live-13.6.0-amd64-gnome.iso`
- 变体说明 = 副文本（12px 灰色）：`Live GNOME · amd64`
- `variant-info` 纵向两行布局

### 3. 全面改用 HTTP 目录页扫描

**你指出的关键问题**：部分架构由缓存加速提供，磁盘扫描不完整 → 删除 `_scan_disk`，全部条目统一 `_scan_http`。`{latest_dir}` 占位符升级为 HTTP 层实现（解析目录页数字开头子目录 + 版本号排序取最新）。

## 验证

**真实 HTTP 全量扫描**：20 条直链全部正确、0 暂不可用（Ubuntu 26.04.1、Debian 13.6.0 全 6 变体、CentOS Stream 10 latest 双架构、Kali 2026.2 双变体、FreeBSD 15.1 三变体、Arch latest、Gentoo 最新、Docker 29.8.0 三平台）

**Playwright**：Debian 面板 6 行变体、等宽文件名完整显示不超面板边界、副文本样式正确
