### PR TITLE
下载弹窗：补齐 Anolis/Fedora/openSUSE/openEuler + 弹窗加大

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.css
@@ -1322,8 +1322,8 @@ input::-moz-focus-inner {
     position: relative;
     display: flex;
     flex-direction: column;
-    width: min(680px, 100%);
-    max-height: min(80vh, 640px);
+    width: min(840px, 100%);
+    max-height: min(80vh, 720px);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -1391,7 +1391,7 @@ input::-moz-focus-inner {
     border-right: 1px solid var(--color-border);
     overflow-y: auto;
     flex-shrink: 0;
-    width: 168px;
+    width: 180px;
 }
 
 .download-nav-item {

--- a/download_items.py
+++ b/download_items.py
@@ -4,11 +4,12 @@
 因为部分架构由缓存加速提供，磁盘扫描不完整）。
 
 字段说明:
-    name        左侧导航显示名
-    base        镜像根路径（URL 相对路径）
-    variants    变体列表，每项:
+    name            左侧导航显示名
+    base            镜像根路径（URL 相对路径）
+    versions_prefix {latest_dir} 匹配子目录的前缀（默认数字开头），如 openEuler 源用 'openEuler-'
+    variants        变体列表，每项:
         note    变体说明（副文本，如「桌面版 · x86_64」）
-        subdir  URL 子路径，支持 {latest_dir} 占位符（版本号数字开头的子目录按版本排序取最新）
+        subdir  URL 子路径，支持 {latest_dir} 占位符（按版本排序取最新子目录）
         glob    文件名匹配模式
 """
 
@@ -39,6 +40,44 @@ OS_ITEMS = [
         'variants': [
             {'note': 'DVD 安装盘 · x86_64', 'subdir': '10-stream/BaseOS/x86_64/iso', 'glob': 'CentOS-Stream-*latest-x86_64-dvd1.iso'},
             {'note': 'DVD 安装盘 · aarch64', 'subdir': '10-stream/BaseOS/aarch64/iso', 'glob': 'CentOS-Stream-*latest-aarch64-dvd1.iso'},
+        ],
+    },
+    {
+        'name': 'Anolis OS',
+        'base': 'anolis',
+        'variants': [
+            {'note': 'DVD 安装盘 · x86_64', 'subdir': '23/isos/GA/x86_64', 'glob': 'AnolisOS-*-x86_64-dvd.iso'},
+            {'note': 'DVD 安装盘 · aarch64', 'subdir': '23/isos/GA/aarch64', 'glob': 'AnolisOS-*-aarch64-dvd.iso'},
+        ],
+    },
+    {
+        'name': 'Fedora',
+        'base': 'fedora',
+        'variants': [
+            {'note': 'Workstation Live · x86_64', 'subdir': 'releases/{latest_dir}/Workstation/x86_64/iso', 'glob': 'Fedora-Workstation-Live-*.x86_64.iso'},
+            {'note': 'Server DVD · x86_64', 'subdir': 'releases/{latest_dir}/Server/x86_64/iso', 'glob': 'Fedora-Server-dvd-x86_64-*.iso'},
+            {'note': 'Server netinst · x86_64', 'subdir': 'releases/{latest_dir}/Server/x86_64/iso', 'glob': 'Fedora-Server-netinst-x86_64-*.iso'},
+            {'note': 'Server DVD · aarch64', 'subdir': 'releases/{latest_dir}/Server/aarch64/iso', 'glob': 'Fedora-Server-dvd-aarch64-*.iso'},
+        ],
+    },
+    {
+        'name': 'openSUSE',
+        'base': 'opensuse',
+        'variants': [
+            {'note': 'Leap 离线安装 · x86_64', 'subdir': 'distribution/leap/{latest_dir}/iso', 'glob': 'Leap-*-offline-installer-x86_64.install.iso'},
+            {'note': 'Leap 在线安装 · x86_64', 'subdir': 'distribution/leap/{latest_dir}/iso', 'glob': 'Leap-*-online-installer-x86_64.install.iso'},
+            {'note': 'Tumbleweed DVD · x86_64', 'subdir': 'tumbleweed/iso', 'glob': 'openSUSE-Tumbleweed-DVD-x86_64-Current.iso'},
+            {'note': 'Tumbleweed NET · x86_64', 'subdir': 'tumbleweed/iso', 'glob': 'openSUSE-Tumbleweed-NET-x86_64-Current.iso'},
+        ],
+    },
+    {
+        'name': 'openEuler',
+        'base': 'openeuler',
+        'versions_prefix': 'openEuler-',
+        'variants': [
+            {'note': '标准安装盘 · x86_64', 'subdir': '{latest_dir}/ISO/x86_64', 'glob': 'openEuler-*-x86_64-dvd.iso'},
+            {'note': '精简安装盘 · x86_64', 'subdir': '{latest_dir}/ISO/x86_64', 'glob': 'openEuler-*-netinst-x86_64-dvd.iso'},
+            {'note': '全量软件盘 · x86_64', 'subdir': '{latest_dir}/ISO/x86_64', 'glob': 'openEuler-*-everything-x86_64-dvd.iso'},
         ],
     },
     {

--- a/mirror_index.py
+++ b/mirror_index.py
@@ -455,7 +455,7 @@ def _match_glob(names, pattern):
 
 def _version_key(name):
     import re
-    return [int(p) if p.isdigit() else p for p in re.split(r'[.-]', name)]
+    return [(0, int(p), '') if p.isdigit() else (1, 0, p) for p in re.split(r'[.-]', name)]
 
 
 def _parse_html_links(html_text):
@@ -477,15 +477,25 @@ def _scan_http(item, variant):
     base_url = MIRROR_WEB_ROOT + '/' + item['base'] + '/'
     subdir = variant.get('subdir', '')
     if '{latest_dir}' in subdir:
-        links = _fetch_dir_links(base_url)
+        before, after = subdir.split('{latest_dir}', 1)
+        list_url = base_url + before if before else base_url
+        links = _fetch_dir_links(list_url)
         if links is None:
             return None
-        version_dirs = sorted({l.rstrip('/') for l in links
-                               if l.rstrip('/').startswith(('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))})
-        if not version_dirs:
+        prefix = item.get('versions_prefix', '')
+        candidates = set()
+        for link in links:
+            name = link.rstrip('/')
+            if prefix:
+                if not name.startswith(prefix) or not name[len(prefix):len(prefix) + 1].isdigit():
+                    continue
+            elif not name[:1].isdigit():
+                continue
+            candidates.add(name)
+        if not candidates:
             return None
-        latest_dir = max(version_dirs, key=_version_key)
-        subdir = subdir.replace('{latest_dir}', latest_dir)
+        latest_dir = max(candidates, key=_version_key)
+        subdir = before + latest_dir + after
     url = base_url + subdir + '/' if subdir else base_url
     links = _fetch_dir_links(url)
     if links is None:

--- a/pages/mirror.css
+++ b/pages/mirror.css
@@ -1322,8 +1322,8 @@ input::-moz-focus-inner {
     position: relative;
     display: flex;
     flex-direction: column;
-    width: min(680px, 100%);
-    max-height: min(80vh, 640px);
+    width: min(840px, 100%);
+    max-height: min(80vh, 720px);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -1391,7 +1391,7 @@ input::-moz-focus-inner {
     border-right: 1px solid var(--color-border);
     overflow-y: auto;
     flex-shrink: 0;
-    width: 168px;
+    width: 180px;
 }
 
 .download-nav-item {


### PR DESCRIPTION
## 问题 1：缺少 Anolis / Fedora / openSUSE / openEuler

**原因：配置遗漏**（非代码 bug）。这四源都是 TUNA 反代页格式，现有 href 正则通吃，补充配置即可。发行版 7 → **11 个**：

| 源 | 新增变体 |
|----|---------|
| Anolis OS | 23.5 GA 双架构 dvd（x86_64 + aarch64） |
| Fedora | 44 Workstation Live + Server dvd / netinst / aarch64 dvd |
| openSUSE | Leap 16.1 offline / online installer + Tumbleweed DVD / NET |
| openEuler | 25.09 标准 / netinst / everything 三盘 |

## 问题 2：弹窗加大

`680 → 840px` 宽、`max-height 640 → 720px`、nav `168 → 180px`。

## 扫描器增强（过程中修的三个 bug）

1. `{latest_dir}` 支持**占位符前置路径**：`releases/{latest_dir}/...`（此前只在 base 顶层探测，Fedora/openSUSE Leap 因此失败）
2. `versions_prefix` 前缀后必须紧跟数字：过滤 `openEuler-Embedded-26.03` / `openEuler-preview` 等非版本目录
3. `_version_key` 混合类型比较崩溃修复（统一元组排序键）
4. Fedora Workstation glob 修正（文件名架构段在版本后：`Fedora-Workstation-Live-44-1.7.x86_64.iso`）

## 验证

**真实 HTTP 全量扫描**：33 条直链全部正确、**0 暂不可用**

**Playwright**：面板 840px 上限 + nav 180px + 内容区加宽；移动端 375px 仍 343px 适配 + bottom sheet 保持
