### PR TITLE
状态页图表左侧留白收紧：containLabel 模式下 left 降为 12px

### DIFF
--- a/pages/status.js
+++ b/pages/status.js
@@ -678,7 +678,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return fmtPct(v); } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 50, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}%' }, max: 100 }),
                 series: series
@@ -718,7 +718,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return fmtBytes(v); } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 60, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: function (v) { return fmtBytes(v); } } }),
                 series: usedSeries.concat(totalSeries)
@@ -752,7 +752,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return fmtPct(v); } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 50, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}%' }, max: 100 }),
                 series: series
@@ -778,7 +778,7 @@
                 backgroundColor: 'transparent',
                 tooltip: baseTooltip(),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 50, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value' }),
                 series: series
@@ -815,7 +815,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return fmtBps(v); } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 60, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: function (v) { return fmtBps(v); } } }),
                 series: rxSeries.concat(txSeries)
@@ -865,7 +865,7 @@
                 animationDelay: function (idx) { return idx * 150; },
                 tooltip: Object.assign(baseTooltip(), { trigger: 'item', valueFormatter: function (v) { return fmtPct(v); } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 60, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: baseAxis({ type: 'value', max: 100, axisLabel: { color: themeColors().text, formatter: '{value}%' } }),
                 yAxis: baseAxis({ type: 'category', data: cats, splitLine: { show: false } }),
                 series: series
@@ -907,7 +907,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { formatter: aggTooltipFormatter(false) }),
                 legend: { top: 0, textStyle: { color: tc.text } },
-                grid: { containLabel: true, left: 60, right: 60, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 60, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: [
                     baseAxis({ type: 'value', name: '负载/核数', nameTextStyle: { color: tc.text }, position: 'left' }),
@@ -949,7 +949,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { formatter: aggTooltipFormatter(true) }),
                 legend: { top: 0, textStyle: { color: tc.text } },
-                grid: { containLabel: true, left: 70, right: 50, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 50, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: [
                     baseAxis({ type: 'value', name: '内存', nameTextStyle: { color: tc.text }, axisLabel: { color: tc.text, formatter: function (v) { return fmtBytes(v); } } }),
@@ -991,7 +991,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { formatter: aggTooltipFormatter(true) }),
                 legend: { top: 0, textStyle: { color: tc.text } },
-                grid: { containLabel: true, left: 70, right: 50, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 50, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: [
                     baseAxis({ type: 'value', name: '磁盘', nameTextStyle: { color: tc.text }, axisLabel: { color: tc.text, formatter: function (v) { return fmtBytes(v); } } }),
@@ -1266,7 +1266,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return v.toFixed(2) + ' req/s'; } }),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 60, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}' } }),
                 series: series
@@ -1301,7 +1301,7 @@
                 backgroundColor: 'transparent',
                 tooltip: baseTooltip(),
                 legend: { top: 0, textStyle: { color: themeColors().text } },
-                grid: { containLabel: true, left: 50, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text } }),
                 series: series
@@ -1339,7 +1339,7 @@
                 backgroundColor: 'transparent',
                 tooltip: baseTooltip(),
                 legend: { top: 0, textStyle: { color: themeColors().text }, type: 'scroll' },
-                grid: { containLabel: true, left: 50, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text } }),
                 series: series
@@ -1375,7 +1375,7 @@
                 backgroundColor: 'transparent',
                 tooltip: Object.assign(baseTooltip(), { valueFormatter: function (v) { return v.toFixed(2) + ' s'; } }),
                 legend: { top: 0, textStyle: { color: themeColors().text }, type: 'scroll' },
-                grid: { containLabel: true, left: 60, right: 20, top: 36, bottom: 30 },
+                grid: { containLabel: true, left: 12, right: 12, top: 36, bottom: 30 },
                 xAxis: timeXAxis(),
                 yAxis: baseAxis({ type: 'value', axisLabel: { color: themeColors().text, formatter: '{value}s' } }),
                 series: series


### PR DESCRIPTION
## 问题

上一轮加 `containLabel: true` 后，`left` 的语义变为**标签之外的额外 padding**——原 50/60px 叠加长标签宽度，左侧总留白超 120px，绘图区被挤右，不协调。

## 修复

额外 padding 统一降为 `12px`（总左边距 = 实际标签宽 + 12）。右侧同理降到 12px；双 Y 轴图（chart-agg-load 等）保留 50/60px 给右侧轴标签。

## 视觉验证

| 指标 | 值 |
|------|-----|
| 左侧留白 | 70px，全部被 Y 轴标签占用（功能性） |
| 绘图区宽度 | ~85%，曲线延伸至边界 |
| 标签完整性 | `500.00 Mbps` 等全部完整 |
