### PR TITLE
Add Debian Security repository

### DIFF
--- a/mirror_index.py
+++ b/mirror_index.py
@@ -378,7 +378,7 @@ html = HEADER
 odd_or_even = 'even'
 
 mirror_list = sorted(glob.glob('/mnt/mirror/*'))
-cdn_mirror_list = ['pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora', 'rubygems', 'composer', 'nuget']
+cdn_mirror_list = ['pypi', 'centos-stream', 'centos-vault', 'anaconda', 'anolis', 'crates.io-index', 'debian-security', 'maven', 'npm', 'kali', 'ubuntu-ports', 'freebsd-pkg', 'docker', 'go', 'openwrt', 'opensuse', 'fedora', 'rubygems', 'composer', 'nuget']
 ignore_dir = ['static', 'font', 'help', 'Nginx-Fancyindex-Theme', 'certs', 'git', 'scripts', 'ubuntu-cloud-images']
 
 for mirror in mirror_list:

--- a/nginx_conf/conf/mirror/mirror.conf
+++ b/nginx_conf/conf/mirror/mirror.conf
@@ -13,6 +13,8 @@ proxy_cache_path /home/mirror/nginx_cache/centos-vault levels=2:2 keys_zone=cach
 proxy_cache_path /home/mirror/nginx_cache/CTAN levels=2:2 keys_zone=cache_CTAN:1m max_size=5G inactive=30d use_temp_path=off;
 # debian （非amd64）缓存
 proxy_cache_path /home/mirror/nginx_cache/debian levels=2:2 keys_zone=cache_debian:1m max_size=5G inactive=30d use_temp_path=off;
+# debian security 缓存
+proxy_cache_path /home/mirror/nginx_cache/debian_security levels=2:2 keys_zone=cache_debian_security:1m max_size=5G inactive=30d use_temp_path=off;
 # epel （非x86_64）缓存
 proxy_cache_path /home/mirror/nginx_cache/epel levels=2:2 keys_zone=cache_epel:1m max_size=5G inactive=30d use_temp_path=off;
 # fedora 缓存
@@ -226,6 +228,30 @@ server {
     location @debian_2h_tuna_tsinghua {
         include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
         proxy_cache cache_debian;
+        include /home/nginx/conf/mirror/cache_2h.conf;
+    }
+
+    ##############################
+    # debian security 配置
+    ##############################
+
+    # 检测到文件不存在则反代到清华
+    location /debian-security/ {
+        try_files $uri $uri/ @debian_tuna_tsinghua;
+    }
+    location ~ /debian-security/.*/(Packages|Packages.gz|InRelease|Release|Release.gpg|Contents-.*.gz) {
+        try_files $uri @debian_2h_tuna_tsinghua;
+    }
+    # 清华缓存 30天
+    location @debian_security_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_debian_security;
+        include /home/nginx/conf/mirror/cache_30d.conf;
+    }
+    # 清华缓存 2小时
+    location @debian_security_2h_tuna_tsinghua {
+        include /home/nginx/conf/mirror/proxy_pass_tsinghua.conf;
+        proxy_cache cache_debian_security;
         include /home/nginx/conf/mirror/cache_2h.conf;
     }
 


### PR DESCRIPTION
This pull request adds support for caching and proxying the Debian Security mirror in both the Python index script and the Nginx configuration. The changes ensure that Debian Security packages are now handled similarly to other mirrors, with appropriate cache paths and proxy rules.

**Debian Security mirror support:**

* Added `debian-security` to the `cdn_mirror_list` in `mirror_index.py` so it is included in the list of supported mirrors.
* Added a new Nginx cache path for Debian Security in `nginx_conf/conf/mirror/mirror.conf`, specifying cache parameters for `/home/mirror/nginx_cache/debian_security`.

**Nginx proxy and caching configuration:**

* Introduced new Nginx `location` blocks for `/debian-security/` to handle proxying and caching, including logic to proxy to Tsinghua if files are missing and to apply different cache durations (30 days and 2 hours) for specific file types.