### PR TITLE
修复 mirrors4/6 域名下当前协议 badge 卡在「检测中」

### DIFF
--- a/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
+++ b/Nginx-Fancyindex-Theme/gdut-mirrors/mirror.js
@@ -481,6 +481,8 @@
             }
         }
 
+        if (onIPv4) setBadge('ipv4', true);
+        if (onIPv6) setBadge('ipv6', true);
         if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { setBadge('ipv6', ok); if (!ok) disableSeg('ipv6'); }));
         if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { setBadge('ipv4', ok); if (!ok) disableSeg('ipv4'); }));
 

--- a/pages/mirror.js
+++ b/pages/mirror.js
@@ -481,6 +481,8 @@
             }
         }
 
+        if (onIPv4) setBadge('ipv4', true);
+        if (onIPv6) setBadge('ipv6', true);
         if (!onIPv6) probes.push(probeProtocol('ipv6').then(function (ok) { setBadge('ipv6', ok); if (!ok) disableSeg('ipv6'); }));
         if (!onIPv4) probes.push(probeProtocol('ipv4').then(function (ok) { setBadge('ipv4', ok); if (!ok) disableSeg('ipv4'); }));
 


### PR DESCRIPTION
## 问题

在 `mirrors4` / `mirrors6` 域名上，**当前协议**行（如 mirrors4 的 IPv4 行）的 badge 永远停在「检测中」；`mirrors`（自动）域名下一切正常。

## 原因

探测逻辑只探测**非当前**协议（mirrors4 上只探 ipv6，跳过 ipv4）——当前协议行的 badge 从初始「检测中」态起无人更新。mirrors 上两个协议都被探测，所以都正常。

## 修复

当前所在协议直接 `setBadge(version, true)` 标绿：能访问当前页面即证明该协议可用，无需探测（与「自动」行静态绿标同一逻辑）。

## Playwright 验证（生产环境 mirrors4 + mirrors6 注入）

| 域名 | 结果 |
|------|------|
| mirrors4 | 三 badge 全「支持 / success」✅ |
| mirrors6 | 三 badge 全「支持 / success」+ 滑块高亮 ipv6 ✅ |
